### PR TITLE
Remove DelayedConnection class

### DIFF
--- a/assets_server/mappers.py
+++ b/assets_server/mappers.py
@@ -8,41 +8,6 @@ from wand.image import Image
 from swiftclient.client import ClientException as SwiftException
 
 
-class DelayedConnection:
-    """
-    Get read to make a Connection, for the FileManager
-    but only actually make the connection when "manager" if first called
-    """
-
-    file_manager = False
-
-    def __init__(
-        self, manager_class, connection_class,
-        auth_url, username, password, auth_version, tenant_name
-    ):
-        self.manager_class = manager_class
-        self.connection_class = connection_class
-        self.auth_url = auth_url
-        self.username = username
-        self.password = password
-        self.auth_version = auth_version
-        self.tenant_name = tenant_name
-
-    def manager(self):
-        if not self.file_manager:
-            self.file_manager = self.manager_class(
-                self.connection_class(
-                    self.auth_url,
-                    self.username,
-                    self.password,
-                    auth_version=self.auth_version,
-                    os_options={'tenant_name': self.tenant_name}
-                )
-            )
-
-        return self.file_manager
-
-
 class FileManager:
     """
     Manage asset files:
@@ -61,9 +26,6 @@ class FileManager:
 
     def __init__(self, swift_connection):
         self.swift_connection = swift_connection
-
-        # Make sure container exists
-        self.swift_connection.put_container(self.container_name)
 
     def create(self, file_data, filename):
         """


### PR DESCRIPTION
If we don't check the container exists when we instantiate FileManager,
which I think isn't necessary, then we can instantiate FileManeger
without the overhead of connecting to Swift until necessary. This renders
DelayedConnection redundant.
