### PR TITLE
Make upload-asset work locally, rather than over HTTP

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,4 +24,3 @@ six==1.6.1
 sphinx-me==0.2.1
 tornado==3.1.1
 wsgiref==0.1.2
-ubuntudesign-asset-mapper==0.3


### PR DESCRIPTION
We had a problem with running `scripts/upload-healthtest.sh` when not using `DEBUG=true`, because the connection was made over HTTP rather than HTTPS, but the server requires HTTPS for API calls.

There is no reason why `upload-asset.py` should use the HTTP-based `AssetMapper` class, rather than using the `FileManager` and `DataManager` classes directly.

I've therefore removed dependency on `ubuntudesign-asset-mapper` and made `upload-asset.py` use the manager classes directly.
