### PR TITLE
Add caching and 304 not modified behaviour

### DIFF
--- a/assets_server/mappers.py
+++ b/assets_server/mappers.py
@@ -105,6 +105,12 @@ class FileManager:
 
         return asset_data
 
+    def headers(self, file_path):
+        return self.swift_connection.head_object(
+            self.container_name,
+            file_path
+        )
+
     def delete(self, file_path):
         self.swift_connection.delete_object(
             self.container_name,


### PR DESCRIPTION
## QA
- Run the server locally
- Upload an asset (you can use `scripts/upload-asset.py`)
- Browse to the asset _with the inspector open_ and inspect headers in the network tab - you should get a 200 response with the asset and a "Cache-Control" and a "Last-Modified" header returned
- Refresh. Now you should see an "If-Modified-Since" header sent, and a 304 status returned.
- Put ".json" on the end of the URL (you'll need to generate and use a token first `scripts/get-token.sh`)
  - Make sure you get `Cache-Control: nocache`
- Check some other API endpoints to make sure they work, all API `GET` responses, that aren't actual assets, should return `Cache-Control: nocache`.
