### PR TITLE
Add "api_test_helpers", restructure a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,5 @@ scripts/get-token.sh tests > tests/fixtures/api-token
 Run the tests with [pytest](http://pytest.org/):
 
 ``` bash
-py.test
+py.test tests/
 ```

--- a/tests/api_test_helpers.py
+++ b/tests/api_test_helpers.py
@@ -17,7 +17,7 @@ def get(params={}, server_url="http://localhost:8012/v1/"):
 
     return requests.get(server_url, params=params)
 
-def get_token(fixtures_path=None):
+def token_fixture(fixtures_path=None):
     """
     Get the token from the fixture file
     """

--- a/tests/test_assets_server.py
+++ b/tests/test_assets_server.py
@@ -1,11 +1,11 @@
-from api_test_helpers import get, get_token
+from api_test_helpers import get, token_fixture
 
 class TestAssetsAPI:
     """
     API tests of the assets server.
     """
 
-    token = get_token()
+    token = token_fixture()
 
     def test_no_token(self):
         assert get().status_code == 403


### PR DESCRIPTION
## Done
- Create new api_test_helpers file
- Move "get" into there
- Create new "token_fixture" function to get token from "tests/fixtures/api-token"
- Update test_assets_server.py to make use of the helpers
- Change instructions in the README to `py.test`
## QA
- Run `py.test tests/` with:
  - No file in `tests/fixtures/api-token`
  - An invalid token in `tests/fixtures/api-token`
  - A valid token `tests/fixtures/api-token`
