### PR TITLE
Remove HTTPS checking - its useless in production

### DIFF
--- a/assets_server/auth.py
+++ b/assets_server/auth.py
@@ -18,18 +18,6 @@ def token_authorization(target_function):
     """
 
     def inner(self, request, *args, **kwargs):
-        # API calls have to be over HTTPS
-        # So if both DEBUG and the request wasn't https, we should redirect
-
-        # This detects if the request was through a secure front-end
-        forwarded_protocol = request.META.get('HTTP_X_FORWARDED_PROTO', '')
-        is_secure = request.is_secure() or forwarded_protocol == 'https'
-
-        if not (settings.DEBUG or is_secure):
-            url = request.build_absolute_uri(request.get_full_path())
-            secure_url = url.replace("http://", "https://")
-            return HttpResponseRedirect(secure_url)
-
         # HTTP authorization header
         auth_header = request.META.get('HTTP_AUTHORIZATION', '')
 


### PR DESCRIPTION
As the application in production has no idea whether it's behind HTTPS or not
it's useless to get it to do any checking.

It's really up to the person who sets up the hosting to make sure it's behind
HTTPS.
## QA

First, on branch master, run: `./manage.py runserver --settings=assets_server.settings`, then visit `http://127.0.0.1:8000/v1/` and confirm you get redirected to `https`.

Then switch to this branch and (in a clean browser session) visit `http://127.0.0.1:8000/v1/` again - you should no longer get redirected.
