### PR TITLE
Handle parameters more gracefully

### DIFF
--- a/assets_server/lib/http_helpers.py
+++ b/assets_server/lib/http_helpers.py
@@ -40,6 +40,10 @@ def error_response(error, file_path=''):
 
     # Get the status from either .errno or .http_status
     status = 500  # Default to "server error"
+
+    if hasattr(error, 'status_code'):
+        status = error.status_code
+
     if hasattr(error, 'errno'):
         if error.errno in [errno.EPERM, errno.EACCES]:
             status = 403  # Forbidden

--- a/assets_server/lib/processors.py
+++ b/assets_server/lib/processors.py
@@ -1,5 +1,22 @@
 from pilbox.image import Image
+from pilbox.errors import PilboxError
 
+
+def catch_missing_param_error(error, operation_name, operation_params):
+    expected_errors = [
+        "int() argument must be a string or a number, not 'NoneType'",
+        "'NoneType' object has no attribute 'split'"
+    ]
+
+    if error.message in expected_errors:
+        message = "Image operation '{0}' requires one of: {1}".format(
+            operation_name,
+            ', '.join(operation_params)
+        )
+
+        raise PilboxError(400, log_message=message)
+    else:
+        raise resize_error
 
 def image_processor(image_stream, params):
     """
@@ -10,28 +27,41 @@ def image_processor(image_stream, params):
 
     image = Image(image_stream)
 
-    op = params.get("op", "resize")
+    op = params.get("op")
 
-    if op == "resize":
-        image.resize(
-            width=params.get("w"),
-            height=params.get("h"),
-            mode=params.get("mode"),
-            filter=params.get("filter"),
-            background=params.get("bg"),
-            position=params.get("pos")
-        )
+    resize_operations = ['w', 'h', 'mode', 'filter', 'bg', 'pos']
+    used_operations = [x for x in params.keys() if x in resize_operations]
 
-    elif op == "region":
-        image.region(
-            params.get("rect").split(',')
-        )
+    if op == "region":
+        try:
+            image.region(
+                params.get("rect").split(',')
+            )
+        except AttributeError as region_error:
+            catch_missing_param_error(region_error, 'rotate', ['rect'])
 
     elif op == "rotate":
-        image.rotate(
-            deg=params.get("deg"),
-            expand=params.get("expand")
-        )
+        try:
+            image.rotate(
+                deg=params.get("deg"),
+                expand=params.get("expand")
+            )
+        except TypeError as rotate_error:
+            catch_missing_param_error(rotate_error, 'rotate', ['deg', 'expand'])
+
+
+    elif op == "resize" or used_operations:
+        try:
+            image.resize(
+                width=params.get("w"),
+                height=params.get("h"),
+                mode=params.get("mode"),
+                filter=params.get("filter"),
+                background=params.get("bg"),
+                position=params.get("pos")
+            )
+        except TypeError as resize_error:
+            catch_missing_param_error(resize_error, 'resize', resize_operations)
 
     return image.save(
         format=params.get("fmt"),


### PR DESCRIPTION
If any parameters were passed to an image that Pilbox didn't understand,
we were getting an internet server error.

We've fixed this by only passing recognised "resize" parameters to Pilbox
(if no "op" setting is supplied)

If you do provide an "op" setting without other parameters, so that Pilbox throws an error
we now provide a nice friendly "400" message.

resolves #25
## QA

@0atman please just pull this down and test the error messages and resize functionality locally wouldya?
