### PR TITLE
409 for submitting dulpicate redirects

### DIFF
--- a/assets_server/views.py
+++ b/assets_server/views.py
@@ -319,7 +319,14 @@ class RedirectRecords(APIView):
             )
 
         elif settings.REDIRECT_MANAGER.exists(redirect_path):
-            raise ParseError('Another redirect with that path already exists')
+            return Response(
+                {
+                    "message": 'Another redirect with that path already exists',
+                    "redirect_path": redirect_path,
+                    "code": 409
+                },
+                status=409
+            )
 
         else:
             redirect_record = settings.REDIRECT_MANAGER.update(


### PR DESCRIPTION
## QA

Run the server:

``` bash
make setup
make develop
```

Then in another tab:

``` bash
$ curl http://127.0.0.1:8012/v1/redirects?token=2f54e1ce8b1c4eb4b2e3274cc86c96f3 -X POST --data "target_url=/foodle&redirect_path=fish" -i
{
    "message": "Redirect created", 
    "target_url": "/foodle", 
    "redirect_path": "fish"
}$ curl http://127.0.0.1:8012/v1/redirects?token=2f54e1ce8b1c4eb4b2e3274cc86c96f3 -X POST --data "target_url=/foodle&redirect_path=fish" -i
HTTP/1.0 409 CONFLICT
Content-Type: application/json
Allow: GET, POST, HEAD, OPTIONS
Connection: close
Server: Werkzeug/0.9.4 Python/2.7.6
Date: Mon, 11 May 2015 12:50:36 GMT

{
    "message": "Another redirect with that path already exists", 
    "code": 409, 
    "redirect_path": "fish"
}
```

^ The second time you try to create this redirect, you should get a 409.
