### PR TITLE
Guess from extension for text files

### DIFF
--- a/assets_server/views.py
+++ b/assets_server/views.py
@@ -67,7 +67,7 @@ class Asset(APIView):
 
         content_type = magic.Magic(mime=True).from_buffer(asset_data)
 
-        if not content_type or content_type == 'text/plain':
+        if not content_type or content_type[:5] == 'text/':
             content_type = mimetypes.guess_type(file_path)[0]
 
         # Start response, guessing mime type


### PR DESCRIPTION
The magic mimetype guesser is great for binary files, but it prone to misinterpreting text files.

Therefore, we should guess the mime type by the file extension when it comes to text files.
