### PR TITLE
Make downloaded assets have nice filenames

### DIFF
--- a/assets_server/lib/file_helpers.py
+++ b/assets_server/lib/file_helpers.py
@@ -38,6 +38,33 @@ def create_asset(
     return url_path
 
 
+def is_hex(hex_string):
+    """
+    Check if a string is hexadecimal
+    """
+
+    try:
+        int(hex_string, 16)
+        return True
+    except ValueError:
+        return False
+
+
+def remove_filename_hash(filename):
+    """
+    Remove the 8-digit unique hexadecimal hash
+    from a filename
+    """
+
+    if is_hex(filename[:8]) and filename[8] == '-':
+        filename = filename[9:]
+
+    return filename
+
+
+# def filename
+
+
 def file_error(error_number, message, filename):
     """
     Create an IOError

--- a/assets_server/lib/processors.py
+++ b/assets_server/lib/processors.py
@@ -44,6 +44,8 @@ class ImageProcessor:
         if converted or transformed or optimize:
             self.optimize(allow_svg_errors=converted or transformed)
 
+        return target_format
+
     def optimize(self, allow_svg_errors=False):
         """
         Optimize SVGs, PNGs or Jpegs


### PR DESCRIPTION
Add filename to "Content-Disposition" header, without any hexadecimal hash prefix.
## QA

In your local assets server, visit an asset with a hash prefix in the browser, and click Ctrl+s or similar to save it - you should see that the filename doesn't contain the hash.

For a further test, try converting an image with `fmt=jpg` or similar, and then try to save it. Make sure the file extension is accurate to the converted image type.
