### PR TITLE
Remove extra slashes in request URLs

### DIFF
--- a/assets_server/views.py
+++ b/assets_server/views.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from urllib import unquote
 import errno
 import mimetypes
+import re
 
 # Packages
 from django.conf import settings
@@ -306,6 +307,9 @@ class RedirectRecords(APIView):
         redirect_path = request.DATA.get('redirect_path').lstrip('/')
         target_url = request.DATA.get('target_url')
 
+        # Remove multiple-slashes
+        redirect_path = re.sub("//+", "/", redirect_path)
+
         body = {
             'redirect_path': redirect_path,
             'target_url': target_url
@@ -405,6 +409,9 @@ class Redirects(APIView):
     """
 
     def get(self, request, request_path):
+        # Remove multiple slashes from path, to make sure things match
+        request_path = re.sub("//+", "/", request_path)
+
         redirect_record = settings.REDIRECT_MANAGER.fetch(request_path)
 
         if not redirect_record:


### PR DESCRIPTION
Remove extra slashes from the redirect path when creating redirects, and then find that redirect even if you include extra slashes in the request.
## QA

Run the server:

``` bash
make setup
make develop
```

Make a token if you don't have one:

``` bash
$ scripts/get-token.sh main
Token 'main' created
{GENERATED_TOKEN}
```

Create a redirect on the command-line, with some extra slashes in the `redirect_path`:

``` bash
$ curl http://127.0.0.1:8012/v1/redirects?token={GENERATED_TOKEN} -X POST --data "target_url=http://google.com&redirect_path=//test//request"
{
    "message": "Redirect created", 
    "target_url": "http://google.com", 
    "redirect_path": "test/request"
}
```

Verify extra slashes are removed in the output above ^.

Then visit `http://127.0.0.1:8012/test////request` (< with some extra slashes) and check the redirect still works.
