### PR TITLE
Ignore case in mongo searches

### DIFF
--- a/assets_server/mappers.py
+++ b/assets_server/mappers.py
@@ -136,7 +136,7 @@ class DataManager:
         return self.format(asset_data) if asset_data else None
 
     def find(self, query):
-        match = re.compile(query)
+        match = re.compile(query, re.IGNORECASE)
 
         results = self.data_collection.find(
             {


### PR DESCRIPTION
Fixes #62.
## QA

``` bash
$ make setup
$ scripts/get-token.sh default
Token 'default' created
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
$ make develop
```

Create a file and upload it:

``` bash
$ touch example-file.txt
$ scripts/upload-asset.sh example-file.txt
da39a3ee-example-file.txt
```

Now try to find it with incorrect case (you'll have to add in the correct auth key):

``` bash
$ curl "http://127.0.0.1:8012/v1/?q=EXAMPLE&token=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
[
    {
        "created": "Thu Jan 28 14:53:47 2016", 
        "file_path": "da39a3ee-example-file.txt", 
        "tags": ""
    }
]
```
