### PR TITLE
Gracefully handle optimization failures

### DIFF
--- a/assets_server/lib/file_helpers.py
+++ b/assets_server/lib/file_helpers.py
@@ -39,7 +39,7 @@ def create_asset(
     settings.FILE_MANAGER.create(file_data, url_path)
 
     # Once the file is created, create file metadata
-    settings.DATA_MANAGER.update(url_path, tags)
+    settings.DATA_MANAGER.update(url_path, tags, optimize)
 
     return url_path
 

--- a/assets_server/mappers.py
+++ b/assets_server/mappers.py
@@ -116,13 +116,16 @@ class DataManager:
     def __init__(self, data_collection):
         self.data_collection = data_collection
 
-    def update(self, file_path, tags):
+    def update(self, file_path, tags, optimized=None):
         search = {"file_path": normalize(file_path)}
 
         data = {
             "file_path": normalize(file_path),
             "tags": tags
         }
+
+        if optimized is not None:
+            data['optimized'] = optimized
 
         self.data_collection.update(search, data, True)
 
@@ -161,6 +164,9 @@ class DataManager:
             'tags': asset_record["tags"] or "",
             'created': asset_record["_id"].generation_time.ctime()
         }
+
+        if 'optimized' in asset_record:
+            asset_data['optimized'] = str(asset_record['optimized'])
 
         return asset_data
 

--- a/scripts/.upload-asset.py
+++ b/scripts/.upload-asset.py
@@ -60,7 +60,8 @@ with open(file_path) as upload_file:
             file_data=upload_file.read(),
             friendly_name=os.path.basename(upload_file.name),
             tags=tags,
-            url_path=url_path
+            url_path=url_path,
+            optimize=optimize
         )
     except IOError, create_error:
         if create_error.errno == errno.EEXIST:


### PR DESCRIPTION
- If an image can't be optimised, continue unoptimized.
- Store "optimized" state against each image
## QA

Fixes #72.

Get the server running:

``` bash
make setup develop
```

Download [ceph-logo.png](http://assets.ubuntu.com/sites/ubuntu/latest/u/img/cloud/storage/ceph-logo.png) and [logo-lenovo.png](https://assets.ubuntu.com/sites/taleo/v2/img/logos/logo-lenovo.png).

Upload both to the local assets server for optimization and check both succeed. However, `logo-lenovo.png` should have been optimized and `ceph-logo.png` should _not_ have been:

``` bash
 $ scripts/upload-asset.sh --optimize=True ceph-logo.png                                                                                                        
 {'optimized': 'False', 'created': 'Fri Jan 29 12:10:43 2016', 'file_path': u'6c2ee5b9-ceph-logo.png', 'tags': ''}
 $ scripts/upload-asset.sh --optimize=True logo-lenovo.png 
 {'optimized': 'True', 'created': 'Fri Jan 29 12:15:23 2016', 'file_path': u'ee196b11-logo-lenovo.png', 'tags': ''}
```

Now check both look okay on the server:
- http://127.0.0.1:8012/v1/6c2ee5b9-ceph-logo.png
- http://127.0.0.1:8012/v1/ee196b11-logo-lenovo.png
