### PR TITLE
add deprecate flag on assets to hide them from search results

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "lint-python": "flake8 --exclude '*env*,node_modules' && black --line-length 79 --check --exclude '(node_modules/.*|[^/]*env[0-9]?/.*)' .",
     "format-python": "black --line-length 79 --exclude '(node_modules/.*|[^/]*env[0-9]?/.*)' .",
     "test-python": "./manage.py test webapp.tests",
-    "test": "yarn run lint && yarn run test-python"
+    "test": "yarn run lint-python && yarn run test-python"
   }
 }

--- a/webapp/lib/file_helpers.py
+++ b/webapp/lib/file_helpers.py
@@ -12,9 +12,14 @@ from .processors import ImageProcessor
 
 
 def create_asset(
-    file_data, friendly_name, tags="", url_path="", optimize=False
+    file_data,
+    friendly_name,
+    tags="",
+    url_path="",
+    optimize=False,
+    deprecated=False,
 ):
-    data = {"optimized": optimize}
+    data = {"tags": tags, "deprecated": deprecated, "optimized": optimize}
 
     if optimize:
         try:
@@ -62,7 +67,7 @@ def create_asset(
         )
 
     # Once the file is created, create file metadata
-    settings.DATA_MANAGER.update(url_path, tags, data)
+    settings.DATA_MANAGER.update(url_path, data)
 
     return url_path
 

--- a/webapp/mappers.py
+++ b/webapp/mappers.py
@@ -109,10 +109,11 @@ class DataManager:
     def __init__(self, data_collection):
         self.data_collection = data_collection
 
-    def update(self, file_path, tags, data={}):
+    def update(self, file_path, data={}):
         search = {"file_path": normalize(file_path)}
 
-        data.update({"file_path": normalize(file_path), "tags": tags})
+        # Set the "file_path" entry in data
+        data.update(search)
 
         self.data_collection.update(search, data, True)
 
@@ -165,6 +166,7 @@ class DataManager:
         asset_data = {
             "file_path": asset_record["file_path"],
             "tags": asset_record["tags"] or "",
+            "deprecated": asset_record.get("deprecated") or False,
             "created": asset_record["_id"].generation_time.ctime(),
         }
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -111,8 +111,11 @@ class Asset(APIView):
         """
 
         tags = request.data.get("tags", "")
+        deprecated = request.data.get("deprecated", False) == "true"
 
-        data = settings.DATA_MANAGER.update(file_path, tags)
+        data = settings.DATA_MANAGER.update(
+            file_path, {"tags": tags, "deprecated": deprecated}
+        )
 
         return Response(data)
 
@@ -153,10 +156,11 @@ class AssetList(APIView):
         Create a new asset
         """
 
-        tags = request.data.get("tags", "")
-        optimize = request.data.get("optimize", False)
         asset = request.data.get("asset")
+        deprecated = request.data.get("deprecated", False)
         friendly_name = request.data.get("friendly-name")
+        optimize = request.data.get("optimize", False)
+        tags = request.data.get("tags", "")
         url_path = request.data.get("url-path", "").strip("/")
 
         try:
@@ -166,6 +170,7 @@ class AssetList(APIView):
                 tags=tags,
                 url_path=url_path,
                 optimize=optimize,
+                deprecated=deprecated,
             )
         except IOError as create_error:
             if create_error.errno == errno.EEXIST:


### PR DESCRIPTION
## Done

- add `deprecated` field to the asset with the default value equals to `false`
- hide assets with `deprecated=true` from the assets list on search

## TODO

- Add a button to make an asset deprecated in the assets manager, where it does a `PUT` request to the endpoint `/v1/file_path/` with the fields `tags` and `deprecated=true`
- Show a deprecated label in the search results if the asset is deprecated

## QA

- Run the server locally `./run`, please follow the `README` in case of first time setup
- Create a dummy asset, you can run the [attached script](https://github.com/canonical-web-and-design/assets.ubuntu.com/files/7392818/insert-deprecated-asset.zip) to create a dummy image with the deprecated flag set to true, usage
```bash
unzip insert-deprecated-asset.zip
./insert-deprecated-asset.sh your-token
```
- Check that the asset is created by going to http://0.0.0.0/v1/friendly-name.png/info?token=your-token and make sure that the response contains details about the asset and the `deprecated` field is set to `true`

## Issue / Card

fixes #98

[insert-deprecated-asset.zip](https://github.com/canonical-web-and-design/assets.ubuntu.com/files/7392818/insert-deprecated-asset.zip)
 