### PR TITLE
Add sentry DSN

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -5,6 +5,9 @@ env:
   - name: FLASK_APP
     value: webapp.app
 
+  - name: SENTRY_DSN
+    value: https://3bc9aa38eda545d6ae399b121811c8d2@sentry.is.canonical.com//56
+
   # Postgres
   - name: DATABASE_URL
     secretKeyRef:


### PR DESCRIPTION
Add DSN for sending sentry errors to https://sentry.is.canonical.com/canonical/assetsubuntucom/