### PR TITLE
Escape unicode file name

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -116,7 +116,7 @@
           function (e) {
             let url = e.target.dataset.url;
             if (url.startsWith("/")) url = `${location.origin}${url}`;
-            copyToClipboard(url);
+            copyToClipboard(encodeURI(url));
           },
           false
         );

--- a/webapp/lib/url_helpers.py
+++ b/webapp/lib/url_helpers.py
@@ -13,3 +13,12 @@ def normalize(url_to_normalize):
     unquoted_url = unquote_plus(url_to_normalize)
     requoted_url = quote_plus(unquoted_url)
     return requoted_url
+
+
+def clean_unicode(file_name):
+    """
+    Given a file name, it will remove any unicode characters
+    that are not supported by the filesystem.
+    """
+    if file_name:
+        return file_name.encode("latin-1", "ignore").decode("latin-1")

--- a/webapp/services.py
+++ b/webapp/services.py
@@ -11,6 +11,7 @@ from wand.image import Image
 # Local
 from webapp.database import db_session
 from webapp.lib.processors import ImageProcessor
+from webapp.lib.url_helpers import clean_unicode
 from webapp.models import Asset, Tag
 from webapp.swift import file_manager
 
@@ -64,6 +65,10 @@ class AssetService:
         """
         Create a new asset
         """
+        # escape unicde characters
+        friendly_name = clean_unicode(friendly_name)
+        url_path = clean_unicode(url_path)
+
         encoded_file_content = (b64decode(file_content),)
         if imghdr.what(None, h=file_content) is not None:
             data["image"] = True


### PR DESCRIPTION
## Done

- Escape non latin-1 characters in assets filename
- Copy the proper URL when a user clicks on the assets Copy to clipboard button

## Issues

Fixes #213  #208 