### PR TITLE
Added config to allow access to internal staging swift

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -68,3 +68,43 @@ staging:
       rewrite ^ https://assets.staging.ubuntu.com/manager$request_uri? permanent;
     }
     more_set_headers "X-Robots-Tag: noindex";
+  env:
+  # Disable proxy for staging-swift
+  - name: NO_PROXY
+    value: .internal,ubuntu.com,.ubuntu.com,snapcraft.io,.snapcraft.io,jujucharms.com,.jujucharms.com,maas.io,.maas.io,conjure-up.io,.conjure-up.io,netplan.io,.netplan.io,canonical.com,.canonical.com,launchpad.net,.launchpad.net,linuxcontainers.org,.linuxcontainers.org,cloud-init.io,.cloud-init.io,vanillaframework.io,.vanillaframework.io,anbox-cloud.io,.anbox-cloud.io,juju.is,.juju.is,dqlite.io,.dqlite.io,charmhub.io,.charmhub.io,staging-swift
+  # Postgres
+  - name: DATABASE_URL
+    secretKeyRef:
+      key: database-url
+      name: assets-ubuntu-swift-staging
+
+  # Swift
+  - name: OS_AUTH_URL
+    secretKeyRef:
+      key: os-auth-url
+      name: assets-ubuntu-swift-staging
+
+  - name: OS_USERNAME
+    secretKeyRef:
+      key: os-username
+      name: assets-ubuntu-swift-staging
+
+  - name: OS_PASSWORD
+    secretKeyRef:
+      key: os-password
+      name: assets-ubuntu-swift-staging
+
+  - name: OS_AUTH_VERSION
+    secretKeyRef:
+      key: os-auth-version
+      name: assets-ubuntu-swift-staging
+
+  - name: OS_TENANT_NAME
+    secretKeyRef:
+      key: os-tenant-name
+      name: assets-ubuntu-swift-staging
+
+  - name: OS_REGION_NAME
+    secretKeyRef:
+      key: os-region-name
+      name: assets-ubuntu-swift-staging


### PR DESCRIPTION
## Done

- Added `staging-swift` to `$NO_PROXY` to allow resolution by the internal k8s DNS
- Added new secrets on staging that point to the `staging-swift` instance

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8017

