### PR TITLE
Make asset type a single select dropdown

### DIFF
--- a/templates/create-update.html
+++ b/templates/create-update.html
@@ -49,9 +49,9 @@
     <div class="row">
       <div class="col-8 col-start-large-5">
         <div class="p-section js-multiselect">
-          <label class="p-heading--5 u-no-margin--bottom is-required" id="asset-type">Asset type(s)</label>
+          <label class="p-heading--5 u-no-margin--bottom is-required" id="asset-type">Asset type</label>
           <p class="u-text--muted u-no-padding--top">For example, image, whitepaper or diagram.</p>
-          <select id="asset-type-select" aria-label="Required field: Select asset type" multiple required>
+          <select id="asset-type-select" aria-label="Required field: Select asset type" required>
             {% for asset_type in data.asset_types %}
               {% set asset_value = asset_type.name|lower|replace(' ', '-') %}
               <option value="{{ asset_value }}" {% if asset and asset_value in asset.asset_type %}selected{% endif %} {% if asset_type.name == "-" %}disabled{% endif %}>

--- a/webapp/swift.py
+++ b/webapp/swift.py
@@ -100,6 +100,7 @@ class FileManager:
 
         return path
 
+
 # Include staging-swift in NO_PROXY
 os.environ["NO_PROXY"] = f"{os.environ.get('NO_PROXY', '')},staging-swift"
 


### PR DESCRIPTION
## Done

- Removed "multiple" attribute from select
- Change "Asset type(s)" to "Asset type"

## QA

- Check out this PR
- Run the project usin
  - `docker compose up -d`
  - `dotrun`
- Open localhost:8017 in your browser
- Go to "Add asset"
- Make sure the "Asset type" field is a single select dropdown.

## Issue / Card

Fixes #[WD-18303](https://warthogs.atlassian.net/browse/WD-18303)

## Screenshots
Before
![image](https://github.com/user-attachments/assets/98f356a4-8949-4ffa-958d-ff49bf5e105f)

After
![image](https://github.com/user-attachments/assets/64cd4047-8916-41aa-83ba-5cee8b0e2ee1)



[WD-18303]: https://warthogs.atlassian.net/browse/WD-18303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ