### PR TITLE
[WD-18220] Prevent form submission on Enter

### DIFF
--- a/static/js/src/main.js
+++ b/static/js/src/main.js
@@ -8,16 +8,6 @@ import './date-picker';
 import './generic-fields';
 
 /*
- * If 'enter' is pressed, submit the form.
- **/
-document.addEventListener('keydown', function (e) {
-  if (e.key === 'Enter') {
-    const form = e.target.closest('form');
-    form.submit();
-  }
-});
-
-/*
  * Event delgation to handle the click event for search and filter.
  **/
 document.addEventListener('click', function (e) {

--- a/webapp/swift.py
+++ b/webapp/swift.py
@@ -100,6 +100,7 @@ class FileManager:
 
         return path
 
+
 # Include staging-swift in NO_PROXY
 os.environ["NO_PROXY"] = f"{os.environ.get('NO_PROXY', '')},staging-swift"
 


### PR DESCRIPTION
## Done

- Removed logic to submit form when pressed Enter in any field

## QA

- Check out this PR
- Run the project using
  - `docker compose up -d`
  - `dotrun`
- Open localhost:8017 in your browser
- Go to "Add asset"
- Press enter within any field and verify the form isn't submitted automatically, unless pressed Enter or clicked on the Submit button

## Issue / Card

Fixes #[WD-18220](https://warthogs.atlassian.net/browse/WD-18220)


[WD-18220]: https://warthogs.atlassian.net/browse/WD-18220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ