### PR TITLE
feat: update image tag format to match our html standards

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -66,7 +66,7 @@
         const img = new Image()
         img.onload = function () {
           imageLoadHandler(`
-          \{\{ image \(
+          \{\{ image\(
             url="${str}",
             alt="",
             width="${this.width}",

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -66,8 +66,7 @@
         const img = new Image()
         img.onload = function () {
           imageLoadHandler(`
-          \{\{ image\(
-            url="${str}",
+          \{\{ image\(url="${str}",
             alt="",
             width="${this.width}",
             height="${this.height}",


### PR DESCRIPTION
## Done

- This updates the `generateImgTag` function to return a properly formatted image tag by removing the spsace between 'image' and '(':
Example:
```
{{ image(
url="https://assets.ubuntu.com/v1/8fc5e716-openstack-logo.png",
alt="Openstack",
width="413",
height="313",
hi_def=True,
loading="auto|lazy"
) | safe
}}
```

## QA

- Run the branch
- Find an image
- Click 'Image tag'
- Check there is no space between 'image' and '('
