### PR TITLE
feat: Refresh assets cards, assets details page and assets uploaded page

### DIFF
--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -11,7 +11,7 @@
 }
 
 .p-asset-card--thumbnail {
-  max-height: 100px;
+  max-height: 200px;
   min-height: 100px;
 }
 

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -15,7 +15,7 @@
   min-height: 100px;
 }
 
-.p-asset-card__image-container {
+.p-asset-card-image__container {
   
   display: flex;           
   justify-content: center;  

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -66,3 +66,10 @@
   background:#f7f7f7;
   margin-top:2rem;
 }
+
+.p-asset-created-details__header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  flex-wrap: wrap
+}

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -11,16 +11,18 @@
 }
 
 .p-asset-card--thumbnail {
-  max-height: 200px;
-  min-height: 100px;
+  max-width: 100%;
+  max-height: 100%;
 }
 
 .p-asset-card-image__container {
-  
   display: flex;           
   justify-content: center;  
   align-items: center;     
-  position: relative;     
+  position: relative;
+  min-height: 200px;
+  max-height: 200px;  
+  overflow: hidden;
 
   &.is-deprecated img{
     opacity: 0.5;
@@ -33,6 +35,7 @@
     padding: 0.8rem;
     background: red;
     color: white;
+    font-weight: bold;
   }
 }
 

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -15,6 +15,27 @@
   min-height: 100px;
 }
 
+.p-asset-card__image-container {
+  
+  display: flex;           
+  justify-content: center;  
+  align-items: center;     
+  position: relative;     
+
+  &.is-deprecated img{
+    opacity: 0.5;
+  }
+
+  &.is-deprecated::after {
+    position: absolute;
+    content: "Deprecated asset";
+    width: max-content;
+    padding: 0.8rem;
+    background: red;
+    color: white;
+  }
+}
+
 .asset-additional-edit-row {
   display: flex;
   flex-direction: row;

--- a/templates/_asset-card-image.html
+++ b/templates/_asset-card-image.html
@@ -6,9 +6,9 @@
       {% endif %}
       <div class="u-sv1">
         <div class="p-section--shallow">
-          <a href="/v1/{{ asset.file_path }}" target="_blank">
-            <div class="p-asset-card__image-container {% if asset.deprecated %}is-deprecated{% endif %}"
-                 style="position: relative">
+          <a href="{% if details or created %}/v1/{{ asset.file_path }}{% else %}/manager/details?file-path={{ asset.file_path }}{% endif %}"
+             target="{% if details or created %}_blank{% else %}_self{% endif %}">
+            <div class="p-asset-card-image__container {% if asset.deprecated %}is-deprecated{% endif %}">
               <img class="p-asset-card--thumbnail"
                    alt=""
                    src="{% if asset.data.image %}/v1/{{ asset.file_path }}{% elif asset.asset_type == 'whitepaper' %}https://assets.ubuntu.com/v1/b061c401-White+paper.svg{% else %}https://assets.ubuntu.com/v1/fd84bbdc-Document-open.svg {% endif %}">

--- a/templates/_asset-card-image.html
+++ b/templates/_asset-card-image.html
@@ -1,51 +1,53 @@
-<div class="p-asset-card p-equal-height-row__col" style="padding:0.75rem;background:#f7f7f7;margin-top:2rem;">
-  <div class="p-equal-height-row__item">
-    {% if asset.data.image %}
-    <a href="/v1/{{ asset.file_path }}" target="_blank">
-      <img
-        class="p-asset-card--thumbnail"
-        src="/v1/{{ asset.file_path }}"
-      />
-    </a>
-    {% endif %}
-  </div>
-  <div class="p-equal-height-row__item">
-    {% if asset.name %}
-      <p class="u-no-margin--bottom"><strong>{{ asset.name }}</strong></p>
-    {% else %}
-      <p class="u-no-margin--bottom"><strong>{{ asset.file_path.split('.')[0] }}</strong></p>
-    {% endif %}
-    <p>File type: <strong>.{{ asset.file_path.split('.', 1)[1] }}</strong></p>
-    <p class="u-no-margin--bottom">Image size: <strong>{% if asset.data.width and asset.data.height %}{{asset.data.width}} x {{asset.data.height}}{% endif %}</strong></p>
-    <p>
-      Tags: 
-      {% for tag in asset.tags %}
-      <strong>{{ tag.name }}{% if not loop.last %},{% endif %}</strong>
-      {% endfor %}
-    </p>
-    <p>
-      <span>Date created: {{ asset.created.strftime('%d %B %Y') }}</span>
-    </p>
-  </div>
-  <div class="p-equal-height-row__item">
-    <p class="p-text--small">
-      <a href="/manager/details?file-path={{ asset.file_path }}">Full asset details&nbsp;&rsaquo;</a>
-    </p>
-  </div>
-  <div class="p-equal-height-row__item">
-    <p class="u-align--right u-no-margin--bottom" style="height:100%">
-      <button
-        class="p-button--positive copy-link is-dense"
-        data-url="/v1/{{ asset.file_path }}"
-      >
-        Asset link
-      </button>
-      <a
-        class="p-button is-dense"
-        href="/manager/update?file-path={{ asset.file_path }}"
-      >
-        Edit asset
-    </a>
-    </p>
+<div class="col-3 col-medium-3">
+  <div class="p-card u-no-padding" style="border: none;">
+    <div class="p-card__content">
+      <div class="u-sv1">
+        <a href="/v1/{{ asset.file_path }}" target="_blank">
+          <img class="p-asset-card--thumbnail"
+               alt=""
+               src="{% if asset.data.image %}/v1/{{ asset.file_path }}{% elif asset.asset_type == 'whitepaper' %}https://assets.ubuntu.com/v1/b061c401-White+paper.svg{% else %}https://assets.ubuntu.com/v1/fd84bbdc-Document-open.svg {% endif %}">
+        </a>
+        {% if asset.name %}
+          <p class="u-no-margin--bottom">
+            <strong>{{ asset.name }}</strong>
+          </p>
+        {% else %}
+          <p class="u-no-margin--bottom">
+            <strong>{{ asset.file_path.split(".")[0] }}</strong>
+          </p>
+        {% endif %}
+        <p class="u-no-margin--bottom">
+          File type: <strong>.{{ asset.file_path.split('.', 1)[1] }}</strong>
+        </p>
+        <p class="u-no-margin--bottom">
+          Resolution:
+          <strong>
+            {% if asset.data.width and asset.data.height %}{{ asset.data.width }} x {{ asset.data.height }}px{% endif %}
+          </strong>
+        </p>
+        <p class="u-no-margin--bottom">Date added: {{ asset.created.strftime("%d %B %Y") }}</p>
+      </div>
+      <hr class="p-rule" />
+      <div class="p-section--shallow">
+        <span>Tags:&nbsp;</span>
+        {% for product in asset.products %}
+          <button class="p-chip is-inline is-dense">
+            <span class="p-chip__value">{{ product.name }}</span>
+          </button>
+        {% endfor %}
+        {% for tag in asset.tags %}
+          <button class="p-chip is-inline is-dense">
+            <span class="p-chip__value">{{ tag.name }}</span>
+          </button>
+        {% endfor %}
+      </div>
+      <div>
+        <button class="p-button--positive copy-link">Asset link</button>
+        <button class="p-button js-copy-image-tag"
+                data-url="/v1/{{ asset.file_path }}">Dev</button>
+        <a class="p-button"
+           href="/manager/update?file-path={{ asset.file_path }}">Edit</a>
+      </div>
+    </div>
   </div>
 </div>

--- a/templates/_asset-card-image.html
+++ b/templates/_asset-card-image.html
@@ -1,4 +1,4 @@
-<div class="col-3 col-medium-3">
+<div class="col-4 col-medium-4">
   <div class="p-card u-no-padding" style="border: none;">
     <div class="p-card__content">
       {% if details %}

--- a/templates/_asset-card-image.html
+++ b/templates/_asset-card-image.html
@@ -51,12 +51,7 @@
       </div>
       {% if details %}
         <hr class="p-rule" />
-        <p class="u-no-margin--bottom">
-          <span>Author:&nbsp;</span>
-          <button class="p-chip is-inline is-dense">
-            <span class="p-chip__value">{{ asset.author.first_name }} {{ asset.author.last_name }}</span>
-          </button>
-        </p>
+        {% include "shared/_asset-author.html" %}
         <p class="u-no-margin--bottom">
           Language: <strong>{{ asset.language }}</strong>
         </p>
@@ -67,18 +62,11 @@
           Google Drive link:  <a href="{{ asset.google_drive_link }}">{{ asset.google_drive_link }}</a>
         </p>
       {% elif created %}
-        <div class="p-section--shallow">
-          <div class="u-sv4"></div>
-        </div>
+        {% include "shared/_asset-card-actions.html" %}
         <p>
           <strong>Asset details</strong>
         </p>
-        <p class="u-no-margin--bottom">
-          <span>Author:&nbsp;</span>
-          <button class="p-chip is-inline is-dense">
-            <span class="p-chip__value">{{ asset.author.first_name }} {{ asset.author.last_name }}</span>
-          </button>
-        </p>
+        {% include "shared/_asset-author.html" %}
         <p class="u-no-margin--bottom">Created: {{ asset.created.strftime("%d %B %Y") }}</p>
         <p class="u-no-margin--bottom">
           Language: <strong>{{ asset.language }}</strong>

--- a/templates/_asset-card-image.html
+++ b/templates/_asset-card-image.html
@@ -5,14 +5,16 @@
         {% include "shared/_asset-card-actions.html" %}
       {% endif %}
       <div class="u-sv1">
-        <a href="/v1/{{ asset.file_path }}" target="_blank">
-          <div class="p-asset-card__image-container {% if asset.deprecated %}is-deprecated{% endif %}"
-               style="position: relative">
-            <img class="p-asset-card--thumbnail"
-                 alt=""
-                 src="{% if asset.data.image %}/v1/{{ asset.file_path }}{% elif asset.asset_type == 'whitepaper' %}https://assets.ubuntu.com/v1/b061c401-White+paper.svg{% else %}https://assets.ubuntu.com/v1/fd84bbdc-Document-open.svg {% endif %}">
-          </div>
-        </a>
+        <div class="p-section--shallow">
+          <a href="/v1/{{ asset.file_path }}" target="_blank">
+            <div class="p-asset-card__image-container {% if asset.deprecated %}is-deprecated{% endif %}"
+                 style="position: relative">
+              <img class="p-asset-card--thumbnail"
+                   alt=""
+                   src="{% if asset.data.image %}/v1/{{ asset.file_path }}{% elif asset.asset_type == 'whitepaper' %}https://assets.ubuntu.com/v1/b061c401-White+paper.svg{% else %}https://assets.ubuntu.com/v1/fd84bbdc-Document-open.svg {% endif %}">
+            </div>
+          </a>
+        </div>
         {% if asset.name %}
           <p class="u-no-margin--bottom">
             <strong>{{ asset.name }}</strong>
@@ -47,9 +49,7 @@
           </button>
         {% endfor %}
       </div>
-      {% if not details %}
-        {% include "shared/_asset-card-actions.html" %}
-      {% else %}
+      {% if details %}
         <hr class="p-rule" />
         <p class="u-no-margin--bottom">
           <span>Author:&nbsp;</span>
@@ -66,6 +66,31 @@
         <p class="u-no-margin--bottom">
           Google Drive link:  <a href="{{ asset.google_drive_link }}">{{ asset.google_drive_link }}</a>
         </p>
+      {% elif created %}
+        <div class="p-section--shallow">
+          <div class="u-sv4"></div>
+        </div>
+        <p>
+          <strong>Asset details</strong>
+        </p>
+        <p class="u-no-margin--bottom">
+          <span>Author:&nbsp;</span>
+          <button class="p-chip is-inline is-dense">
+            <span class="p-chip__value">{{ asset.author.first_name }} {{ asset.author.last_name }}</span>
+          </button>
+        </p>
+        <p class="u-no-margin--bottom">Created: {{ asset.created.strftime("%d %B %Y") }}</p>
+        <p class="u-no-margin--bottom">
+          Language: <strong>{{ asset.language }}</strong>
+        </p>
+        <p class="u-no-margin--bottom">
+          Salesforce campaign ID: <strong>{{ asset.salesforce_campaign_id }}</strong>
+        </p>
+        <p class="u-no-margin--bottom">
+          Google Drive link:  <a href="{{ asset.google_drive_link }}">{{ asset.google_drive_link }}</a>
+        </p>
+      {% else %}
+        {% include "shared/_asset-card-actions.html" %}
       {% endif %}
     </div>
   </div>

--- a/templates/_asset-card-image.html
+++ b/templates/_asset-card-image.html
@@ -1,11 +1,17 @@
 <div class="col-3 col-medium-3">
   <div class="p-card u-no-padding" style="border: none;">
     <div class="p-card__content">
+      {% if details %}
+        {% include "shared/_asset-card-actions.html" %}
+      {% endif %}
       <div class="u-sv1">
         <a href="/v1/{{ asset.file_path }}" target="_blank">
-          <img class="p-asset-card--thumbnail"
-               alt=""
-               src="{% if asset.data.image %}/v1/{{ asset.file_path }}{% elif asset.asset_type == 'whitepaper' %}https://assets.ubuntu.com/v1/b061c401-White+paper.svg{% else %}https://assets.ubuntu.com/v1/fd84bbdc-Document-open.svg {% endif %}">
+          <div class="p-asset-card__image-container {% if asset.deprecated %}is-deprecated{% endif %}"
+               style="position: relative">
+            <img class="p-asset-card--thumbnail"
+                 alt=""
+                 src="{% if asset.data.image %}/v1/{{ asset.file_path }}{% elif asset.asset_type == 'whitepaper' %}https://assets.ubuntu.com/v1/b061c401-White+paper.svg{% else %}https://assets.ubuntu.com/v1/fd84bbdc-Document-open.svg {% endif %}">
+          </div>
         </a>
         {% if asset.name %}
           <p class="u-no-margin--bottom">
@@ -41,13 +47,26 @@
           </button>
         {% endfor %}
       </div>
-      <div>
-        <button class="p-button--positive copy-link">Asset link</button>
-        <button class="p-button js-copy-image-tag"
-                data-url="/v1/{{ asset.file_path }}">Dev</button>
-        <a class="p-button"
-           href="/manager/update?file-path={{ asset.file_path }}">Edit</a>
-      </div>
+      {% if not details %}
+        {% include "shared/_asset-card-actions.html" %}
+      {% else %}
+        <hr class="p-rule" />
+        <p class="u-no-margin--bottom">
+          <span>Author:&nbsp;</span>
+          <button class="p-chip is-inline is-dense">
+            <span class="p-chip__value">{{ asset.author.first_name }} {{ asset.author.last_name }}</span>
+          </button>
+        </p>
+        <p class="u-no-margin--bottom">
+          Language: <strong>{{ asset.language }}</strong>
+        </p>
+        <p class="u-no-margin--bottom">
+          Salesforce campaign ID: <strong>{{ asset.salesforce_campaign_id }}</strong>
+        </p>
+        <p class="u-no-margin--bottom">
+          Google Drive link:  <a href="{{ asset.google_drive_link }}">{{ asset.google_drive_link }}</a>
+        </p>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/templates/_asset-list.html
+++ b/templates/_asset-list.html
@@ -3,9 +3,5 @@
 {% endif %}
 
 {% for asset in assets %}
-  {% if asset.data.image %}
-    {% include "_asset-card-image.html" %}
-  {% else %}
-    {% include "_asset-card.html" %}
-  {% endif %}
+  {% include "_asset-card-image.html" %}
 {% endfor %}

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -70,8 +70,7 @@
         const img = new Image()
         img.onload = function () {
           imageLoadHandler(`
-          \{\{ image\(
-            url="${str}",
+          \{\{ image\(url="${str}",
             alt="",
             width="${this.width}",
             height="${this.height}",

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -70,7 +70,8 @@
         const img = new Image()
         img.onload = function () {
           imageLoadHandler(`
-          \{\{ image\(url="${str}",
+          \{\{ image\(
+            url="${str}",
             alt="",
             width="${this.width}",
             height="${this.height}",

--- a/templates/created.html
+++ b/templates/created.html
@@ -1,30 +1,54 @@
 {% extends "_layout.html" %}
-
 {% block title %}Created assets{% endblock %}
-
 {% block content %}
-<div class="p-strip is-shallow">
-  {% if failed %}
-  <div class="row">
-    <h2>Failed to upload {{failed|length}} assets</h2>
-    {% for failure in failed %}
-    <p>{{failure.file_path}} - <code>{{failure.error}}</code></p>
-    {% endfor %}
+  {% set created = True %}
+  <div class="p-strip is-shallow">
+    <div class="u-fixed-width">
+      <div class="p-section--shallow">
+        <h1 class="p-muted-heading">Upload complete</h1>
+        <hr class="p-rule" />
+      </div>
+    </div>
+    {% if assets %}
+      <div class="p-section--shallow">
+        <div class="u-fixed-width">
+          <div class="p-section--shallow">
+            <div class="p-asset-created-details__header">
+              <h2>{{ assets|length }} asset(s) added to asset manager</h2>
+              <a href="/manager/create" class="p-button--positive">Add another asset</a>
+            </div>
+          </div>
+        </div>
+        <div class="row">{% include "_asset-list.html" %}</div>
+      </div>
+    {% endif %}
+    {% if existing %}
+      {% set assets = existing %}
+      <div class="p-section--shallow">
+        <div class="u-fixed-width">
+          <div class="p-section--shallow">
+            <div class="p-asset-created-details__header">
+              <h2>{{ assets|length }} existing asset(s)</h2>
+              <button class="p-button--positive">Add another asset</button>
+            </div>
+          </div>
+        </div>
+        <div class="row">{% include "_asset-list.html" %}</div>
+      </div>
+    {% endif %}
+    {% if failed %}
+      {% set assets = failed %}
+      <div class="p-section--shallow">
+        <div class="u-fixed-width">
+          <div class="p-section--shallow">
+            <div class="p-asset-created-details__header">
+              <h2>{{ assets|length }} asset(s) failed to upload</h2>
+              <a href="/manager/create" class="p-button--positive">Add another asset</a>
+            </div>
+          </div>
+        </div>
+        <div class="row">{% include "_asset-list.html" %}</div>
+      </div>
+    {% endif %}
   </div>
-  {% endif %}
-  {% if assets %}
-  <div class="p-equal-height-row">
-    <h2>{{assets|length}} assets created</h2>
-    {% include "_asset-list.html" %}
-  </div>
-  {% endif %}
-
-  {% if existing %}
-  <div class="p-equal-height-row">
-    {% set assets = existing %}
-    <h2>{{existing|length}} existing assets</h2>
-    {% include "_asset-list.html" %}
-  </div>
-  {% endif %}
-</div>
 {% endblock %}

--- a/templates/details.html
+++ b/templates/details.html
@@ -1,64 +1,17 @@
 {% extends "_layout.html" %}
-
 {% block title %}Asset details{% endblock %}
-
 {% block content %}
-<div class="p-strip is-shallow">
-  <div class="row">
-    <div class="col-4">
-      <h2>Asset details</h2>
-      <a href="/v1/{{ asset.file_path }}" target="_blank">
-        {% if asset.data.image %}
-          <img
-            src="/v1/{{ asset.file_path }}"
-          />
-        {% elif asset.asset_type == "whitepaper" %}
-          <img class="p-asset-card--thumbnail" src="https://assets.ubuntu.com/v1/b061c401-White+paper.svg" alt="">
-        {% else %}
-          <img class="p-asset-card--thumbnail" src="https://assets.ubuntu.com/v1/fd84bbdc-Document-open.svg" alt="">
-        {% endif %}
-      </a>
-      <p>File path:<strong>{{ asset.file_path }}</strong></p>
-      <p>Name: <strong>{{ asset.name }}</strong></p>
-      <p>File type: <strong>.{{ asset.file_path.split('.', 1)[1] }}</strong></p>
-      <p>Asset type: <strong>{{ asset.asset_type }}</strong></p>
-      {% if asset.data.image %}
-        <p>Image size: <strong>{% if asset.data.width and asset.data.height %}{{asset.data.width}} x {{asset.data.height}}{% else %}Unknown{% endif %}</strong></p>
-      {% endif %}
-      <p>
-        Products:
-        {% for product in asset.products %}
-        <strong>{{ product.name }}{% if not loop.last %},{% endif %}</strong>
-        {% endfor %}
-      </p>
-      <p>
-        Tags: 
-        {% for tag in asset.tags %}
-        <strong>{{ tag.name }}{% if not loop.last %},{% endif %}</strong>
-        {% endfor %}
-      </p>
-      <p>Language: <strong>{{ asset.language }}</strong></p>
-      <p>Salesforce campaign ID: <strong>{{ asset.salesforce_campaign_id }}</strong></p>
-      <p>Google drive link: <a href="{{ asset.google_drive_link }}">{{ asset.google_drive_link }}</a></p>
-      <p>Author email: <strong>{{ asset.author_email }}</strong></p>
-      <p>Deprecated: <strong>{{ asset.deprecated }}</strong></p>
-      <p>Created: {{ asset.created.strftime('%d %B %Y') }}</p>
-      <p>Updated: {{ asset.updated.strftime('%d %B %Y') }}</p>
-      <p style="height:100%">
-        <button
-          class="p-button--positive copy-link is-dense"
-          data-url="/v1/{{ asset.file_path }}"
-        >
-          Asset link
-        </button>
-        <a
-        class="p-button is-dense"
-        href="/manager/update?file-path={{ asset.file_path }}"
-        >
-          Edit asset
-        </a>
-      </p>
+  <div class="p-strip is-shallow">
+    <div class="u-fixed-width">
+      <div class="p-section--shallow">
+        <h1 class="p-muted-heading">Asset details</h1>
+        <hr class="p-rule" />
+      </div>
+    </div>
+    <div class="row">
+      {% with details=True %}
+        {% include "_asset-card-image.html" %}
+      {% endwith %}
     </div>
   </div>
-</div>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,8 +10,8 @@
   </div>
 </div>
 {% include "_pagination.html" %}
-<div class="p-section--shallow">
-  <div class="p-equal-height-row">
+<div class="p-strip is-shallow">
+  <div class="row">
     {% if assets %}
       {% include "_asset-list.html" %}
     {% elif request.values.get("q", None) %}

--- a/templates/shared/_asset-author.html
+++ b/templates/shared/_asset-author.html
@@ -1,0 +1,8 @@
+<p class="u-no-margin--bottom">
+    <span>Author:&nbsp;</span>
+    {% if asset.author %}
+        <button class="p-chip is-inline is-dense">
+            <span class="p-chip__value">{{ asset.author.first_name }} {{ asset.author.last_name }}</span>
+        </button>
+    {% endif %}
+</p>

--- a/templates/shared/_asset-author.html
+++ b/templates/shared/_asset-author.html
@@ -1,6 +1,6 @@
 <p class="u-no-margin--bottom">
     <span>Author:&nbsp;</span>
-    {% if asset.author %}
+    {% if asset.author | trim %}
         <button class="p-chip is-inline is-dense">
             <span class="p-chip__value">{{ asset.author.first_name }} {{ asset.author.last_name }}</span>
         </button>

--- a/templates/shared/_asset-card-actions.html
+++ b/templates/shared/_asset-card-actions.html
@@ -1,7 +1,7 @@
 <div class="p-section--shallow">
-    <button class="p-button--positive copy-link">Asset link</button>
-    <button class="p-button js-copy-image-tag"
-            data-url="/v1/{{ asset.file_path }}">Dev</button>
-    <a class="p-button"
-       href="/manager/update?file-path={{ asset.file_path }}">Edit</a>
+        <button class="p-button--positive copy-link">Asset link</button>
+        <button class="p-button js-copy-image-tag"
+                data-url="/v1/{{ asset.file_path }}">Dev tag</button>
+        <a class="p-button"
+           href="/manager/update?file-path={{ asset.file_path }}">Edit</a>
 </div>

--- a/templates/shared/_asset-card-actions.html
+++ b/templates/shared/_asset-card-actions.html
@@ -1,0 +1,7 @@
+<div class="p-section--shallow">
+    <button class="p-button--positive copy-link">Asset link</button>
+    <button class="p-button js-copy-image-tag"
+            data-url="/v1/{{ asset.file_path }}">Dev</button>
+    <a class="p-button"
+       href="/manager/update?file-path={{ asset.file_path }}">Edit</a>
+</div>

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -53,6 +53,9 @@ class Author(Base):
     last_name = Column(String, nullable=False, primary_key=True)
     email = Column(String, nullable=False, unique=True, primary_key=True)
 
+    def __str__(self):
+        return f"{self.first_name} {self.last_name}"
+
 
 class Asset(DateTimeMixin):
     __tablename__ = "asset"

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -3,7 +3,6 @@ import re
 from distutils.util import strtobool
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
-import flask
 
 # Packages
 from flask import Blueprint

--- a/webapp/services.py
+++ b/webapp/services.py
@@ -12,10 +12,8 @@ from PIL import Image as PillowImage
 
 # Local
 from webapp.database import db_session
-from webapp.lib.file_helpers import is_svg
 from webapp.lib.processors import ImageProcessor
 from webapp.lib.url_helpers import clean_unicode
-from webapp.models import Asset, Tag
 from webapp.lib.file_helpers import is_svg
 from webapp.models import Asset, Tag, Product, Author
 from webapp.swift import file_manager
@@ -32,9 +30,9 @@ class AssetService:
 
     def find_assets(
         self,
-        tag:str = "abc",
+        tag: str = "abc",
         asset_type: str = "image",
-        product_types: list = ["a","b"],
+        product_types: list = ["a", "b"],
         author_email: str = "abc@g.com",
         name: str = "%",
         start_date: str = "2024-01-01",
@@ -49,7 +47,7 @@ class AssetService:
     ) -> Tuple[list, int]:
         """
         Find assets that matches the given criterions
-        """    
+        """
         conditions = []
         if tag:
             conditions.append(Asset.tags.any(Tag.name == tag))
@@ -62,18 +60,20 @@ class AssetService:
         if language:
             conditions.append(Asset.language.ilike(f"{language}"))
         if salesforce_campaign_id:
-            conditions.append(Asset.salesforce_campaign_id.ilike(f"{salesforce_campaign_id}"))
-        
+            conditions.append(
+                Asset.salesforce_campaign_id.ilike(f"{salesforce_campaign_id}")
+            )
+
         if not include_deprecated:
             conditions.append(Asset.deprecated.is_(False))
-        
+
         if order_by == Asset.file_path:
             # Example: "86293d6f-FortyCloud.png" -> "FortyCloud.png"
             order_col = func.split_part(Asset.file_path, "-", 2)
         else:
             order_col = order_by
 
-        if (end_date and start_date):
+        if end_date and start_date:
             conditions.append(Asset.created.between(start_date, end_date))
         if product_types:
             conditions.append(


### PR DESCRIPTION
## Done

- Refreshed the following as per design
  - asset cards - [design](https://www.figma.com/design/dOz7GIHMmofSdje0l0pVFs/Asset-manager?node-id=419-8588&t=UZ3aZAUCsUZj6ymP-4)
  - asset details page - [design](https://www.figma.com/design/dOz7GIHMmofSdje0l0pVFs/Asset-manager?node-id=420-11490&t=UZ3aZAUCsUZj6ymP-4)
  - asset uploaded page - [design](https://www.figma.com/design/dOz7GIHMmofSdje0l0pVFs/Asset-manager?node-id=419-9345&t=oNJYDAi7UR1PL1Dr-4)

## QA

- Check out this feature branch
- Run the site locally using
   - `docker compose up -d`
   - `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8017/manager
- Upload some assets if not already existing.
- Verify the asset uploaded page conforms to the [design](https://www.figma.com/design/dOz7GIHMmofSdje0l0pVFs/Asset-manager?node-id=419-9345&t=oNJYDAi7UR1PL1Dr-4)
- Navigate to the index page by clicking on the application logo in the top left corner
- Verify the asset card confirms to the [design](https://www.figma.com/design/dOz7GIHMmofSdje0l0pVFs/Asset-manager?node-id=419-8588&t=UZ3aZAUCsUZj6ymP-4)
- Click on any asset and verify the asset details page conforms to the [design](https://www.figma.com/design/dOz7GIHMmofSdje0l0pVFs/Asset-manager?node-id=420-11490&t=UZ3aZAUCsUZj6ymP-4)
- Edit any asset and mark it as deprecated. Verify the asset card shows "deprecated" status as in the [design](https://www.figma.com/design/dOz7GIHMmofSdje0l0pVFs/Asset-manager?node-id=419-9273&t=9zTJsq8iNNpDVdw8-0)

## Issue / Card

Fixes 
[#WD-19193](https://warthogs.atlassian.net/browse/WD-19193)
[#WD-19214](https://warthogs.atlassian.net/browse/WD-19214)
[#WD-19196](https://warthogs.atlassian.net/browse/WD-19196)
[#WD-19192](https://warthogs.atlassian.net/browse/WD-19192)
