### PR TITLE
fix: broken link, pagination bugs

### DIFF
--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -76,3 +76,7 @@
   justify-content: space-between;
   flex-wrap: wrap
 }
+
+.p-link--disabled {
+  pointer-events: none;
+}

--- a/templates/_pagination.html
+++ b/templates/_pagination.html
@@ -16,7 +16,7 @@
         </li>
         {% if page > 3 %}<li class="p-pagination__item p-pagination__item--truncation u-hide--small">…</li>{% endif %}
         {% for p in range(page - 1, page + max_pagination_items) %}
-          {% if p > 1 and p < total_pages %}
+          {% if p > 1 and p <= total_pages %}
             <li class="p-pagination__item">
               <a class="p-pagination__link u-no-margin--bottom {{ 'is-active' if page == p }}"
                 href="{{ add_query_param('page', p) }}">{{ p }}</a>

--- a/templates/_pagination.html
+++ b/templates/_pagination.html
@@ -5,7 +5,7 @@
     <nav class="p-pagination" aria-label="Pagination">
       <ol class="p-pagination__items u-align--right">
         <li class="p-pagination__item">
-          <a class="p-pagination__link--previous u-no-margin--bottom {{ 'is-active' if page == 1 }}"
+          <a class="p-pagination__link--previous u-no-margin--bottom {{ 'is-active is-disabled p-link--disabled' if page == 1 }}"
             href="{{ add_query_param('page', page - 1) }}">
             <i class="p-icon--chevron-down">Previous page</i>
           </a>
@@ -32,14 +32,12 @@
               href="{{ add_query_param('page', total_pages) }}">{{ total_pages }}</a>
           </li>
         {% endif %}
-        {% if page < total_pages %}
           <li class="p-pagination__item">
-            <a class="p-pagination__link--next u-no-margin--bottom {{ 'is-active' if page == total_pages }}"
+            <a class="p-pagination__link--next u-no-margin--bottom {{ 'is-active is-disabled p-link--disabled' if page == total_pages }}"
               href="{{ add_query_param('page', page + 1) }}">
               <i class="p-icon--chevron-down">Next page</i>
             </a>
           </li>
-        {% endif %}
         <script>
           function changePerPage(select) {
             var url = new URL(window.location.href);

--- a/templates/shared/_asset-card-actions.html
+++ b/templates/shared/_asset-card-actions.html
@@ -1,5 +1,6 @@
 <div class="p-section--shallow">
-        <button class="p-button--positive copy-link">Asset link</button>
+        <button class="p-button--positive copy-link"
+                data-url="/v1/{{ asset.file_path }}">Asset link</button>
         <button class="p-button js-copy-image-tag"
                 data-url="/v1/{{ asset.file_path }}">Dev tag</button>
         <a class="p-button"

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -79,7 +79,7 @@ def home():
     )
 
     if not per_page or per_page < 1 or per_page > 100:
-        per_page = 8
+        per_page = 6
     if order_by not in asset_service.order_by_fields():
         order_by = list(asset_service.order_by_fields().keys())[0]
     if order_dir not in ["asc", "desc"]:

--- a/webapp/services.py
+++ b/webapp/services.py
@@ -40,7 +40,7 @@ class AssetService:
         salesforce_campaign_id: str = "1234",
         language: str = "en",
         page=1,
-        per_page=8,
+        per_page=6,
         order_by=Asset.created,
         desc_order=True,
         include_deprecated=False,


### PR DESCRIPTION
## Done

- Fixed the copy asset link
- Show correct number of pages in pagination
- Disable previous/next buttons on reaching limits

## QA

- Check out this feature branch
- Run the site using the commands `docker compose up -d` and `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8017/manager
- Upload assets if not already have
- Click on the "Asset link" button
- Verify the link is copied to clipboard
- Make sure you have enough assets to test pagination
- Verify the number of pages are correct according to the total number of assets
- Verify the previous button is disabled on first page, and next button is disabled on last page
