### PR TITLE
feat: save local swift uploads

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,8 +10,11 @@ services:
     ports:
       - "5432:5432"
   swift:
-    image: bouncestorage/swift-aio:latest
+    image: openstackswift/saio:latest
     ports:
       - "8080:8080"
+    volumes:
+      - swift-data:/srv
 volumes:
   postgres-data:
+  swift-data:


### PR DESCRIPTION
## Done

- Updated local swift to save uploaded images between restarts.

## QA

- Check out this feature branch
- Run services using `docker compose up -d`
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8017, upload a file and save the asset link.
- Run `docker compose down` and then `docker compose up -d`
- Try to access the file via the asset link.
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

