### PR TITLE
feat: updated endpoint for cli uploads

### DIFF
--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -4,22 +4,19 @@ import re
 from distutils.util import strtobool
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
+# Packages
 import flask
 import yaml
-
-# Packages
 from flask import Blueprint
 from flask.globals import request
 
-from webapp.param_parser import parse_asset_search_params
-
 # Local
+from webapp.param_parser import parse_asset_search_params
 from webapp.services import (
     AssetAlreadyExistException,
     AssetNotFound,
     asset_service,
 )
-from webapp.param_parser import parse_asset_search_params
 from webapp.sso import login_required
 from webapp.views import (
     create_asset,
@@ -35,9 +32,9 @@ from webapp.views import (
     get_redirects,
     get_token,
     get_tokens,
+    get_users,
     update_asset,
     update_redirect,
-    get_users,
 )
 
 ui_blueprint = Blueprint("ui_blueprint", __name__, url_prefix="/manager")

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -219,7 +219,7 @@ def create():
             optimize=optimize,
         )
 
-    elif request.method == "GET":
+    if request.method == "GET":
         # Repopulate the form with stored data
         form_data = flask.session.pop("form_data", {})
         return flask.render_template(

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -4,12 +4,14 @@ import re
 from distutils.util import strtobool
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
+import flask
+import yaml
 
 # Packages
 from flask import Blueprint
 from flask.globals import request
-import flask
-import yaml
+
+from webapp.param_parser import parse_asset_search_params
 
 # Local
 from webapp.services import (

--- a/webapp/services.py
+++ b/webapp/services.py
@@ -30,7 +30,6 @@ class AssetService:
 
     def find_assets(
         self,
-        asset_name: str = "new",
         tag: str = "abc",
         asset_type: str = "image",
         product_types: list = ["a", "b"],
@@ -59,8 +58,6 @@ class AssetService:
                     Asset.file_path.ilike(f"%{tag}%"),
                 ),
             )
-        if asset_name:
-            conditions.append(Asset.name.ilike(f"%{asset_name}%"))
         if asset_type:
             conditions.append(Asset.asset_type == asset_type)
         if author_email:

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1,13 +1,13 @@
 # Standard library
-import base64
 import math
 import re
 import uuid
-import requests
 from datetime import datetime
 from distutils.util import strtobool
-from urllib.parse import unquote, urlparse
 from os import environ
+from urllib.parse import unquote, urlparse
+
+import requests
 
 # Packages
 from flask import Response, abort, jsonify, redirect, request
@@ -203,12 +203,12 @@ def get_assets():
             asset_type=search_params.asset_type,
             product_types=search_params.product_types,
             author_email=search_params.author_email,
-            name=search_params.name,
+            asset_name=search_params.name,
             start_date=search_params.start_date,
             end_date=search_params.end_date,
             salesforce_campaign_id=search_params.salesforce_campaign_id,
             language=search_params.language,
-            file_type=file_type,
+            file_types=[file_type],
             page=page,
             per_page=per_page,
             include_deprecated=include_deprecated,
@@ -489,5 +489,4 @@ def get_users(username: str):
     if response.status_code == 200:
         users = response.json().get("data", {}).get("employees", [])
         return jsonify(list(users))
-    else:
-        return jsonify({"error": "Failed to fetch users"}), 500
+    return jsonify({"error": "Failed to fetch users"}), 500

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -203,7 +203,6 @@ def get_assets():
             asset_type=search_params.asset_type,
             product_types=search_params.product_types,
             author_email=search_params.author_email,
-            asset_name=search_params.name,
             start_date=search_params.start_date,
             end_date=search_params.end_date,
             salesforce_campaign_id=search_params.salesforce_campaign_id,

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -243,7 +243,10 @@ def create_asset():
         products = request.values.get("products", "").split(",")
         url_path = request.values.get("url-path", "").strip("/")
         asset_type = request.values.get("asset-type", "")
-        author = request.values.get("author", "")
+        author_email = request.values.get("author", "")
+        _author = {
+            "email": author_email,
+        }
         google_drive_link = request.values.get("google_drive_link", "")
         salesforce_campaign_id = request.values.get(
             "salesforce_campaign_id",
@@ -265,7 +268,7 @@ def create_asset():
                     products=products,
                     url_path=url_path,
                     asset_type=asset_type,
-                    author=author,
+                    author=_author,
                     google_drive_link=google_drive_link,
                     salesforce_campaign_id=salesforce_campaign_id,
                     language=language,


### PR DESCRIPTION
## Done

- Updated new fields for asset manager api. To be merged with https://github.com/canonical/assets.ubuntu.com/pull/278

## QA

- This branch has been deployed to staging.
- Open staging, upload assets with all fields and confirm that there are no errors.
  - As a bonus, try searching for these assets.
- Clone this [upload-assets branch](https://github.com/canonical/canonicalwebteam.upload-assets/compare/update-uploader), install using `pip install .` and attempt to upload a file, using additional fields e.g `tags`, `products`.
  - e.g `upload-assets --tags new,test testfile.png`
  - Credentials for upload to staging are provided [here](https://pastebin.canonical.com/p/5MgCjZ2DBx/)
- Try to search for this asset at https://manager.assets.staging.ubuntu.com/manager
- Try to reference this asset at https://manager.assets.staging.ubuntu.com/v1/asset-name

## Fixes
[WD-21376](https://warthogs.atlassian.net/browse/WD-21376)

[WD-21376]: https://warthogs.atlassian.net/browse/WD-21376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ