### PR TITLE
fix: use email data as default author's name

### DIFF
--- a/webapp/services.py
+++ b/webapp/services.py
@@ -286,6 +286,9 @@ class AssetService:
 
         possible_names = email.split("@")[0].split(".")
         # If not supplied, we use the email to get the first name
+        # The reason we want to derive this from the email is that most emails
+        # follow a predictable fname.lname@host format, and not all authors
+        # might be on launchpad (especially for cli tools).
         if not (first_name := author.get("first_name")):
             first_name = possible_names[0]
 

--- a/webapp/services.py
+++ b/webapp/services.py
@@ -289,11 +289,14 @@ class AssetService:
         if not (first_name := author.get("first_name")):
             first_name = possible_names[0]
 
-        if not (last_name := author.get("last_name")) and len(
-            possible_names < 2
-        ):
-            # If we still don't have a last name, use a reversed first name
-            last_name = first_name[::-1]
+        # If we don't have a last name
+        if not (last_name := author.get("last_name")):
+            try:
+                # use name from email
+                last_name = possible_names[1]
+            except IndexError:
+                # or a reversed first_name
+                last_name = first_name[::-1]
 
         existing_author = (
             db_session.query(Author).filter_by(email=email).first()

--- a/webapp/services.py
+++ b/webapp/services.py
@@ -284,11 +284,15 @@ class AssetService:
         if not (email := author.get("email")):
             return None
 
+        possible_names = email.split("@")[0].split(".")
         # If not supplied, we use the email to get the first name
-        if not author.get("first_name"):
-            first_name, last_name = email.split("@")[0].split(".")
-        # If we still don't have a last name, use a reversed first name
-        if not author.get("last_name"):
+        if not (first_name := author.get("first_name")):
+            first_name = possible_names[0]
+
+        if not (last_name := author.get("last_name")) and len(
+            possible_names < 2
+        ):
+            # If we still don't have a last name, use a reversed first name
             last_name = first_name[::-1]
 
         existing_author = (


### PR DESCRIPTION
## Done

- Fixed the reference to required author fields when creating an asset. 
The reason we want to derive these fields (if not supplied) from the email is that _most_ emails follow a predictable `fname.lname@host` format, and not all authors might be on launchpad (especially for cli tools).

## QA

- This branch has been deployed to staging. Open https://manager.assets.staging.ubuntu.com/manager and upload an asset, with the 'author' field filled out. 
- Also edit the asset, and change the author.
- There should be no errors.
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

### Bonus QA
- Upload a file using the [upload-assets](https://github.com/canonical/canonicalwebteam.upload-assets) tool, using the `--author` flag. Any errors here are not strictly related to this PR and will be addressed separately