### PR TITLE
Bugfix: Fixed URL for directory API

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -478,7 +478,7 @@ def get_users(username: str):
 
     headers = {"Authorization": "token " + environ.get("DIRECTORY_API_TOKEN")}
     response = requests.post(
-        "https://directory.wpe.internal/graphql/",
+        "https://api.directory.canonical.com/graphql/",
         json={
             "query": query,
             "variables": {"name": username.strip()},


### PR DESCRIPTION
## Done

- Fixed URL for directory API

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8017
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check if users are being loaded up on create-asset view.

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
