### PR TITLE
feat: Add 'Results per page' selector

### DIFF
--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -89,3 +89,15 @@
 .added-chips {
   background-color: #f7f7f7;
 }
+
+.p-form--per-page-select {
+  .p-form__label {
+    margin-right: 0;
+  }
+  .p-form__control {
+    max-width: fit-content;min-width: 0;padding-right: 2rem;
+  }
+  .p-button {
+    margin-left:0.5rem;
+  }
+}

--- a/templates/_pagination.html
+++ b/templates/_pagination.html
@@ -1,61 +1,78 @@
 {% set max_pagination_items = 3 %}
-<div class="row--50-50">
-  <div class="col">
-    {% if total_assets %}
-      <p id="assets_count" class="u-no-margin--bottom">{{ total_assets }} asset{{ "s" if total_assets > 1 }} match{{ "es" if total_assets < 2 }} your search</p>
-      <div class="u-hide--large u-sv3"></div>
-    {% endif %}
-  </div>
-  {% if total_pages > 1 %}
+<div class="p-section--deep">
+  <div class="row--50-50">
     <div class="col">
-      <nav class="p-pagination" aria-label="Pagination">
-        <ol class="p-pagination__items u-align--right">
-          <li class="p-pagination__item">
-            <a class="p-pagination__link--previous u-no-margin--bottom {{ 'is-active is-disabled p-link--disabled' if page == 1 }}"
-               href="{{ add_query_param('page', page - 1) }}">
-              <i class="p-icon--chevron-down">Previous page</i>
-            </a>
-          </li>
-          <li class="p-pagination__item">
-            <a class="p-pagination__link u-no-margin--bottom {{ 'is-active' if page == 1 }}"
-               href="{{ add_query_param('page', 1) }}">1</a>
-          </li>
-          {% if page > 3 %}<li class="p-pagination__item p-pagination__item--truncation u-hide--small">…</li>{% endif %}
-          {% for p in range(page - 1, page + max_pagination_items) %}
-            {% if p > 1 and p <= total_pages %}
+      {% if total_pages > 1 %}
+        <nav class="p-pagination" aria-label="Pagination">
+          <ol class="p-pagination__items u-align--left">
+            <li class="p-pagination__item">
+              <a class="p-pagination__link--previous u-no-margin--bottom {{ 'is-active is-disabled p-link--disabled' if page == 1 }}"
+                 href="{{ add_query_param('page', page - 1) }}">
+                <i class="p-icon--chevron-down">Previous page</i>
+              </a>
+            </li>
+            <li class="p-pagination__item">
+              <a class="p-pagination__link u-no-margin--bottom {{ 'is-active' if page == 1 }}"
+                 href="{{ add_query_param('page', 1) }}">1</a>
+            </li>
+            {% if page > 3 %}<li class="p-pagination__item p-pagination__item--truncation u-hide--small">…</li>{% endif %}
+            {% for p in range(page - 1, page + max_pagination_items) %}
+              {% if p > 1 and p <= total_pages %}
+                <li class="p-pagination__item">
+                  <a class="p-pagination__link u-no-margin--bottom {{ 'is-active' if page == p }}"
+                     href="{{ add_query_param('page', p) }}">{{ p }}</a>
+                </li>
+              {% endif %}
+            {% endfor %}
+            {% if page + max_pagination_items < total_pages %}
+              <li class="p-pagination__item p-pagination__item--truncation u-hide--small">…</li>
+            {% endif %}
+            {% if total_pages > max_pagination_items and page + max_pagination_items <= total_pages %}
               <li class="p-pagination__item">
-                <a class="p-pagination__link u-no-margin--bottom {{ 'is-active' if page == p }}"
-                   href="{{ add_query_param('page', p) }}">{{ p }}</a>
+                <a class="p-pagination__link u-no-margin--bottom {{ 'is-active' if page == total_pages }}"
+                   href="{{ add_query_param('page', total_pages) }}">{{ total_pages }}</a>
               </li>
             {% endif %}
-          {% endfor %}
-          {% if page + max_pagination_items < total_pages %}
-            <li class="p-pagination__item p-pagination__item--truncation u-hide--small">…</li>
-          {% endif %}
-          {% if total_pages > max_pagination_items and page + max_pagination_items <= total_pages %}
             <li class="p-pagination__item">
-              <a class="p-pagination__link u-no-margin--bottom {{ 'is-active' if page == total_pages }}"
-                 href="{{ add_query_param('page', total_pages) }}">{{ total_pages }}</a>
+              <a class="p-pagination__link--next u-no-margin--bottom {{ 'is-active is-disabled p-link--disabled' if page == total_pages }}"
+                 href="{{ add_query_param('page', page + 1) }}">
+                <i class="p-icon--chevron-down">Next page</i>
+              </a>
             </li>
-          {% endif %}
-          <li class="p-pagination__item">
-            <a class="p-pagination__link--next u-no-margin--bottom {{ 'is-active is-disabled p-link--disabled' if page == total_pages }}"
-               href="{{ add_query_param('page', page + 1) }}">
-              <i class="p-icon--chevron-down">Next page</i>
-            </a>
-          </li>
-          <script>
-          function changePerPage(select) {
-            var url = new URL(window.location.href);
-            url.searchParams.set('per_page', select.value);
-            url.searchParams.set('page', 1);
-            window
-              .location
-              .href = url.href;
-          }
-          </script>
-        </ol>
-      </nav>
+          </ol>
+        </nav>
+      {% endif %}
     </div>
-  {% endif %}
+    <div class="col u-align--right">
+      <form method="get"
+            action=""
+            class="p-form p-form--inline p-form--per-page-select">
+        <div class="p-form__group">
+          <label class="p-form__label" for="assets-per-page">Results by page:</label>
+          <select class="p-form__control u-no-margin--bottom"
+                  id="assets-per-page"
+                  name="per_page"
+                  onchange="this.form.submit()">
+            <option value="10"
+                    {% if request.args.get('per_page') == '10' %}selected{% endif %}>10</option>
+            <option value="20"
+                    {% if request.args.get('per_page') == '20' %}selected{% endif %}>20</option>
+            <option value="50"
+                    {% if request.args.get('per_page') == '50' %}selected{% endif %}>50</option>
+            <option value="100"
+                    {% if request.args.get('per_page') == '100' %}selected{% endif %}>100</option>
+          </select>
+          <input type="hidden" name="page" value="1" />
+          {% for param_name, param_value in request.args.items() %}
+            {% if param_name != 'per_page' and param_name != 'page' %}
+              <input type="hidden" name="{{ param_name }}" value="{{ param_value }}" />
+            {% endif %}
+          {% endfor %}
+          <noscript>
+            <button type="submit" class="p-button">Apply</button>
+          </noscript>
+        </div>
+      </form>
+    </div>
+  </div>
 </div>

--- a/templates/_pagination.html
+++ b/templates/_pagination.html
@@ -54,11 +54,11 @@
                   name="per_page"
                   onchange="this.form.submit()">
             <option value="10"
-                    {% if request.args.get('per_page') == '10' %}selected{% endif %}>10</option>
+                    {% if request.args.get('per_page') == '15' %}selected{% endif %}>15</option>
             <option value="20"
-                    {% if request.args.get('per_page') == '20' %}selected{% endif %}>20</option>
+                    {% if request.args.get('per_page') == '30' %}selected{% endif %}>30</option>
             <option value="50"
-                    {% if request.args.get('per_page') == '50' %}selected{% endif %}>50</option>
+                    {% if request.args.get('per_page') == '60' %}selected{% endif %}>60</option>
             <option value="100"
                     {% if request.args.get('per_page') == '100' %}selected{% endif %}>100</option>
           </select>

--- a/templates/_pagination.html
+++ b/templates/_pagination.html
@@ -53,11 +53,11 @@
                   id="assets-per-page"
                   name="per_page"
                   onchange="this.form.submit()">
-            <option value="10"
+            <option value="15"
                     {% if request.args.get('per_page') == '15' %}selected{% endif %}>15</option>
-            <option value="20"
+            <option value="30"
                     {% if request.args.get('per_page') == '30' %}selected{% endif %}>30</option>
-            <option value="50"
+            <option value="60"
                     {% if request.args.get('per_page') == '60' %}selected{% endif %}>60</option>
             <option value="100"
                     {% if request.args.get('per_page') == '100' %}selected{% endif %}>100</option>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,31 +1,42 @@
 {% extends "_layout.html" %}
 
-{% block title %}Search assets{% endblock title %}
+{% block title %}
+  Search assets
+{% endblock title %}
 
 {% block content %}
 
-<div class="p-strip is-shallow">
-  <div class="u-fixed-width">
-    {% include "_search-form.html" %}
-  </div>  
-  <div class="u-fixed-width">
-    {% if assets %}
-      <h3 class="p-heading--5 p-text--small-caps">Search results</h3>
-    {% elif is_search %}
-      <h3 class="p-heading--5 p-text--small-caps">No results. Please try another search.</h3>
-    {% else %}
-      <h3 class="p-heading--5 p-text--small-caps">Start a search to show assets.</h3>
-    {% endif %}
+  <div class="p-strip is-shallow">
+    <div class="u-fixed-width">{% include "_search-form.html" %}</div>
+    <div class="u-fixed-width">
+      {% if assets %}
+        <h3 class="p-heading--5 p-text--small-caps">Search results</h3>
+      {% elif is_search %}
+        <h3 class="p-heading--5 p-text--small-caps">No results. Please try another search.</h3>
+      {% else %}
+        <h3 class="p-heading--5 p-text--small-caps">Start a search to show assets.</h3>
+      {% endif %}
+    </div>
+    <hr class="p-rule is-fixed-width" />
   </div>
-  <hr class="p-rule is-fixed-width" />
-</div>
-{% include "_pagination.html" %}
-<div class="p-strip is-shallow">
-  <div class="row">
-    {% if assets %}
-      {% include "_asset-list.html" %}
-    {% endif %}
+
+  {% if total_assets %}
+    <div class="u-fixed-width">
+      <p id="assets_count" class="u-no-margin--bottom">
+        {{ total_assets }} asset{{ "s" if total_assets > 1 }} match{{ "es" if total_assets < 2 }} your search
+      </p>
+      <div class="u-hide--large u-sv3"></div>
+    </div>
+  {% endif %}
+
+  <div class="p-strip is-shallow u-no-padding--bottom">
+    <div class="row">
+      {% if assets %}
+        {% include "_asset-list.html" %}
+      {% endif %}
+    </div>
   </div>
-</div>
+
+  {% include "_pagination.html" %}
 
 {% endblock content %}

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -79,7 +79,7 @@ def home():
     )
 
     if not per_page or per_page < 1 or per_page > 100:
-        per_page = 6
+        per_page = 15
     if order_by not in asset_service.order_by_fields():
         order_by = list(asset_service.order_by_fields().keys())[0]
     if order_dir not in ["asc", "desc"]:


### PR DESCRIPTION
## Done

- Adds a no js 'Results per page' selector based on the pagination on the [CVE's search](https://ubuntu.com/security/cves?version=noble&version=jammy&version=focal&version=bionic&version=xenial&version=trusty&version=plucky&version=oracular)
- Ran DJlint

## QA

- Check out this feature branch
- Start the DB with the command `docker-compose up -d`
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8017
- Make sure you have at least twenty assets that you can get the DB to return in a single search
- Find 'Results per page' select at the bottom of the page, defaults to 10
- Increase to 20 and check it refreshes the pages to show 20 results, it is present in the url params as `per_page=20` and the select has the appropriate number pre-selected
- Check that it takes you back to page 1 on selection
- Disable JS and see a 'Apply' button appears and the filter still works

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-21413

## Screenshots

![image](https://github.com/user-attachments/assets/62e56488-d19a-491b-85f9-30892ee98ae6)

