### PR TITLE
Make tag chips clickable

### DIFF
--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -89,3 +89,7 @@
 .added-chips {
   background-color: #f7f7f7;
 }
+
+a.p-chip {
+  background-color: var(--vf-color-background-neutral-default);
+}

--- a/templates/_asset-card-image.html
+++ b/templates/_asset-card-image.html
@@ -54,9 +54,9 @@
           </button>
         {% endfor %}
         {% for tag in asset.tags %}
-          <button class="p-chip is-inline is-dense">
+          <a href="/manager?tag={{tag.name}}" class="p-chip is-inline is-dense">
             <span class="p-chip__value">{{ tag.name }}</span>
-          </button>
+          </a>
         {% endfor %}
       </div>
       {% if details %}

--- a/templates/_asset-card-image.html
+++ b/templates/_asset-card-image.html
@@ -49,7 +49,7 @@
       <div class="p-section--shallow">
         <span>Tags:&nbsp;</span>
         {% for product in asset.products %}
-          <a href="/manager?tag={{product.slug}}" class="p-chip is-inline is-dense">
+          <a href="/manager?tag={{product.name}}" class="p-chip is-inline is-dense">
             <span class="p-chip__value">{{ product.name }}</span>
           </a>
         {% endfor %}

--- a/templates/_asset-card-image.html
+++ b/templates/_asset-card-image.html
@@ -49,9 +49,9 @@
       <div class="p-section--shallow">
         <span>Tags:&nbsp;</span>
         {% for product in asset.products %}
-          <button class="p-chip is-inline is-dense">
+          <a href="/manager?tag={{product.slug}}" class="p-chip is-inline is-dense">
             <span class="p-chip__value">{{ product.name }}</span>
-          </button>
+          </a>
         {% endfor %}
         {% for tag in asset.tags %}
           <a href="/manager?tag={{tag.name}}" class="p-chip is-inline is-dense">


### PR DESCRIPTION
## Done

- Make tag chips clickable

## QA

- Check out this feature branch
- Start the DB with the command docker-compose up -d
- Run the site using the command dotrun
- View the site locally in your web browser at: http://0.0.0.0:8017
- Make sure you have at least 1 asset with a tag
- Find it through the search and click on the tag chip:
![image](https://github.com/user-attachments/assets/3ed38ffe-65a9-4ccd-a8bc-b8d6aa6b022e)
- See that it takes you to http://0.0.0.0:8017/manager?tag=test` and clears all other filters

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-22469
