### PR TITLE
fix: Use ubuntu-latest for test-python ci check

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -31,7 +31,7 @@ jobs:
           curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost
 
   run-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     services:
       postgres:


### PR DESCRIPTION
## Done

- A fix for the run-test's CI action

## QA

- See that the `run-test` action runs and passes on this PR

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-22519
