### PR TITLE
Fix: check for missing language and author fields on old assets

### DIFF
--- a/templates/create-update.html
+++ b/templates/create-update.html
@@ -152,7 +152,7 @@
                 </div>
               </div>
             </div>
-            {% if asset and asset.author.email and asset.author.first_name and asset.author.last_name %}
+            {% if asset and asset.author and asset.author.email and asset.author.first_name and asset.author.last_name %}
               {% set email = asset.author.email %}
               {% set first_name = asset.author.first_name %}
               {% set last_name = asset.author.last_name %}
@@ -265,7 +265,7 @@
                       aria-label="language">
                 {% for language in form_field_data.languages %}
                   <option value="{{ language.name }}"
-                          {% if asset and language.name in asset.language %}selected{% endif %}
+                          {% if asset and asset.language and language.name in asset.language %}selected{% endif %}
                           {% if language.name == "-" %}disabled{% endif %}>{{ language.name }}</option>
                 {% endfor %}
               </select>


### PR DESCRIPTION
## Done

Fix page breaking due to missing Language field on old assets

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8017
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

Fixes # [WD-22826](https://warthogs.atlassian.net/browse/WD-22826)


[WD-22826]: https://warthogs.atlassian.net/browse/WD-22826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ