### PR TITLE
Feat: Migrated to 8-col grid from Legacy grid

### DIFF
--- a/templates/_asset-card-image.html
+++ b/templates/_asset-card-image.html
@@ -1,4 +1,4 @@
-<div class="col-4 col-medium-4">
+<div class="grid-col-2 grid-col-medium-2">
   <div class="p-card u-no-padding" style="border: none;">
     <div class="p-card__content">
       {% if details %}
@@ -10,17 +10,17 @@
              target="{% if details or created %}_blank{% else %}_self{% endif %}">
             <div class="p-asset-card-image__container {% if asset.deprecated %}is-deprecated{% endif %}">
               {% if asset.data.image %}
-              <img class="p-asset-card--thumbnail"
-                   alt=""
-                   src="/v1/{{ asset.file_path }}" />
+                <img class="p-asset-card--thumbnail"
+                     alt=""
+                     src="/v1/{{ asset.file_path }}" />
               {% elif asset.asset_type == 'whitepaper' %}
-              <img class="p-asset-card--thumbnail"
-                   alt=""
-                   src="https://assets.ubuntu.com/v1/b061c401-White+paper.svg" />     
+                <img class="p-asset-card--thumbnail"
+                     alt=""
+                     src="https://assets.ubuntu.com/v1/b061c401-White+paper.svg" />
               {% else %}
-              <img class="p-asset-card--thumbnail"
-                   alt=""
-                   src="https://assets.ubuntu.com/v1/fd84bbdc-Document-open.svg" />
+                <img class="p-asset-card--thumbnail"
+                     alt=""
+                     src="https://assets.ubuntu.com/v1/fd84bbdc-Document-open.svg" />
               {% endif %}
             </div>
           </a>
@@ -35,7 +35,7 @@
           </p>
         {% endif %}
         <p class="u-no-margin--bottom">
-          File type: <strong>.{{ asset.file_type or asset.file_path.split(".")[-1].lower() }}</strong>
+          File type: <strong>.{{ asset.file_type or asset.file_path.split(".")[-1] .lower() }}</strong>
         </p>
         <p class="u-no-margin--bottom">
           Resolution:
@@ -43,18 +43,21 @@
             {% if asset.data.width and asset.data.height %}{{ asset.data.width }} x {{ asset.data.height }}px{% endif %}
           </strong>
         </p>
-        <p class="u-no-margin--bottom">Date added: <strong>{{ asset.created.strftime("%d %B %Y") }}</strong></p>
+        <p class="u-no-margin--bottom">
+          Date added: <strong>{{ asset.created.strftime("%d %B %Y") }}</strong>
+        </p>
       </div>
       <hr class="p-rule" />
       <div class="p-section--shallow">
         <span>Tags:&nbsp;</span>
         {% for product in asset.products %}
-          <a href="/manager?tag={{product.name}}" class="p-chip is-inline is-dense">
+          <a href="/manager?tag={{ product.name }}"
+             class="p-chip is-inline is-dense">
             <span class="p-chip__value">{{ product.name }}</span>
           </a>
         {% endfor %}
         {% for tag in asset.tags %}
-          <a href="/manager?tag={{tag.name}}" class="p-chip is-inline is-dense">
+          <a href="/manager?tag={{ tag.name }}" class="p-chip is-inline is-dense">
             <span class="p-chip__value">{{ tag.name }}</span>
           </a>
         {% endfor %}
@@ -77,7 +80,9 @@
           <strong>Asset details</strong>
         </p>
         {% include "shared/_asset-author.html" %}
-        <p class="u-no-margin--bottom">Created: <strong>{{ asset.created.strftime("%d %B %Y") }}</strong></p>
+        <p class="u-no-margin--bottom">
+          Created: <strong>{{ asset.created.strftime("%d %B %Y") }}</strong>
+        </p>
         <p class="u-no-margin--bottom">
           Language: <strong>{{ asset.language }}</strong>
         </p>

--- a/templates/_pagination.html
+++ b/templates/_pagination.html
@@ -1,7 +1,7 @@
 {% set max_pagination_items = 3 %}
 <div class="p-section--deep">
-  <div class="row--50-50">
-    <div class="col">
+  <div class="grid-row">
+    <div class="grid-col-4 grid-col-medium-2">
       {% if total_pages > 1 %}
         <nav class="p-pagination" aria-label="Pagination">
           <ol class="p-pagination__items u-align--left">
@@ -43,7 +43,7 @@
         </nav>
       {% endif %}
     </div>
-    <div class="col u-align--right">
+    <div class="grid-col-4 grid-col-medium-2  u-align--right">
       <form method="get"
             action=""
             class="p-form p-form--inline p-form--per-page-select">
@@ -53,13 +53,13 @@
                   id="assets-per-page"
                   name="per_page"
                   onchange="this.form.submit()">
-            <option value="15"
-                    {% if request.args.get('per_page') == '15' %}selected{% endif %}>15</option>
-            <option value="30"
-                    {% if request.args.get('per_page') == '30' %}selected{% endif %}>30</option>
-            <option value="60"
-                    {% if request.args.get('per_page') == '60' %}selected{% endif %}>60</option>
-            <option value="100"
+            <option value="16"
+                    {% if request.args.get('per_page') == '16' %}selected{% endif %}>16</option>
+            <option value="32"
+                    {% if request.args.get('per_page') == '32' %}selected{% endif %}>32</option>
+            <option value="64"
+                    {% if request.args.get('per_page') == '64' %}selected{% endif %}>64</option>
+            <option value="128"
                     {% if request.args.get('per_page') == '100' %}selected{% endif %}>100</option>
           </select>
           <input type="hidden" name="page" value="1" />

--- a/templates/_search-form.html
+++ b/templates/_search-form.html
@@ -6,8 +6,8 @@
     <hr class="p-rule" />
   </div>
   {% set params = request.values.to_dict() %}
-  <div class="row">
-    <div class="col-3">
+  <div class="grid-row">
+    <div class="grid-col-2">
       <p>
         <label for="tag">
           <strong>Search</strong>
@@ -18,9 +18,9 @@
              name="tag"
              placeholder="Search asset name, file name, tag(s)"
              id="tag"
-             value="{%- if params.tag -%}{{ params.tag }}{%- endif -%}">
+             value="{%- if params.tag -%}{{ params.tag }}{%- endif -%}" />
     </div>
-    <div class="col-3">
+    <div class="grid-col-2">
       <div class="js-select">
         <p>
           <label for="asset-type">
@@ -38,7 +38,7 @@
         </select>
       </div>
     </div>
-    <div class="col-3">
+    <div class="grid-col-2">
       <div class="js-select">
         <p>
           <label for="asset-type">
@@ -54,7 +54,7 @@
         </select>
       </div>
     </div>
-    <div class="col-3">
+    <div class="grid-col-2">
       <div class="js-select">
         <p>
           <label for="asset-type">

--- a/templates/create-update.html
+++ b/templates/create-update.html
@@ -10,11 +10,11 @@
         <h1 class="p-text--small-caps">Upload Asset(s)</h1>
         <hr class="p-rule" />
         <div class="p-section">
-          <div class="row--50-50">
-            <div class="col">
+          <div class="grid-row">
+            <div class="grid-col-4 grid-col-medium-2">
               <h2>Add a file and fill in mandatory information</h2>
             </div>
-            <div class="col">
+            <div class="grid-col-4 grid-col-medium-2">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
               <div class="p-section--shallow">
                 {% if is_update %}
@@ -241,11 +241,11 @@
       </div>
       <hr class="p-rule" />
       <div class="p-section">
-        <div class="row--50-50">
-          <div class="col">
+        <div class="grid-row">
+          <div class="grid-col-4 grid-col-medium-2">
             <h2>Add optional information</h2>
           </div>
-          <div class="col">
+          <div class="grid-col-4 grid-col-medium-2">
             <div class="p-section--shallow" data-name="googleDriveLink">
               <label class="p-heading--5 u-no-margin--bottom">Google Drive link</label>
               <span class="p-tooltip--right" aria-describedby="google-drive-link-info">
@@ -287,11 +287,11 @@
       </div>
       <hr class="p-rule" />
       <div class="p-section--deep">
-        <div class="row--50-50">
-          <div class="col">
+        <div class="grid-row">
+          <div class="grid-col-4 grid-col-medium-2">
             <h2>Check the information is correct</h2>
           </div>
-          <div class="col">
+          <div class="grid-col-4 grid-col-medium-2">
             <div class="p-strip is-shallow">
               <button class="p-button--positive" type="submit">
                 {% if is_update %}

--- a/templates/created.html
+++ b/templates/created.html
@@ -1,5 +1,7 @@
 {% extends "_layout.html" %}
+
 {% block title %}Created assets{% endblock %}
+
 {% block content %}
   {% set created = True %}
   <div class="p-strip is-shallow">
@@ -19,7 +21,7 @@
             </div>
           </div>
         </div>
-        <div class="row">{% include "_asset-list.html" %}</div>
+        <div class="grid-row">{% include "_asset-list.html" %}</div>
       </div>
     {% endif %}
     {% if existing %}
@@ -33,7 +35,7 @@
             </div>
           </div>
         </div>
-        <div class="row">{% include "_asset-list.html" %}</div>
+        <div class="grid-row">{% include "_asset-list.html" %}</div>
       </div>
     {% endif %}
     {% if failed %}
@@ -49,7 +51,12 @@
         </div>
         <div class="u-fixed-width">
           <ul class="p-list">
-            {% for asset in assets %}<li class="p-list__item">{{ asset.file_path }}{% if asset.error %} :{{ asset.error }}{% endif %}</li>{% endfor %}
+            {% for asset in assets %}
+              <li class="p-list__item">
+                {{ asset.file_path }}
+                {% if asset.error %}:{{ asset.error }}{% endif %}
+              </li>
+            {% endfor %}
           </ul>
         </div>
       </div>

--- a/templates/details.html
+++ b/templates/details.html
@@ -1,5 +1,7 @@
 {% extends "_layout.html" %}
+
 {% block title %}Asset details{% endblock %}
+
 {% block content %}
   <div class="p-strip is-shallow">
     <div class="u-fixed-width">
@@ -8,7 +10,7 @@
         <hr class="p-rule" />
       </div>
     </div>
-    <div class="row">
+    <div class="grid-row">
       {% with details=True %}
         {% include "_asset-card-image.html" %}
       {% endwith %}

--- a/templates/error.html
+++ b/templates/error.html
@@ -2,27 +2,35 @@
 
 {% block title %}{{ code }}: {{ reason }}{% endblock %}
 
-
 {% block content %}
-<div class="p-strip is-deep">
-  <div class="row u-equal-height">
-    <div class="col-6 u-vertically-center u-align--center">
-      <img src="https://assets.ubuntu.com/v1/bcdcf2c8-image-404.svg" alt="" height="365" width="360">
-    </div>
-    <div class="col-6 u-vertically-center">
-      <div>
-        <h1>{{ code }}: {{ reason }}</h1>
-        <p class="p-heading--four">Something's gone wrong.</p>
-        {% if message %}<blockquote><code>{{ message }}</code></blockquote>{% endif %}
-        {% if code != 404 %}
-          <p>
-            Try reloading the page.
-            If the error persists, please note that it may be a <a class="p-link--external" href="https://github.com/canonical-websites/assets.ubuntu.com/issues">known issue</a>.
-            If not, please <a class="p-link--external" href="https://github.com/canonical-websites/assets.ubuntu.com/issues/new">file a new issue</a>.
-          </p>
-        {% endif %}
+  <div class="p-strip is-deep">
+    <div class="grid-row u-equal-height">
+      <div class="grid-col-4 u-vertically-center u-align--center">
+        <img src="https://assets.ubuntu.com/v1/bcdcf2c8-image-404.svg"
+             alt=""
+             height="365"
+             width="360" />
+      </div>
+      <div class="grid-col-4 u-vertically-center">
+        <div>
+          <h1>{{ code }}: {{ reason }}</h1>
+          <p class="p-heading--four">Something's gone wrong.</p>
+          {% if message %}
+            <blockquote>
+              <code>{{ message }}</code>
+            </blockquote>
+          {% endif %}
+          {% if code != 404 %}
+            <p>
+              Try reloading the page.
+              If the error persists, please note that it may be a <a class="p-link--external"
+    href="https://github.com/canonical-websites/assets.ubuntu.com/issues">known issue</a>.
+              If not, please <a class="p-link--external"
+    href="https://github.com/canonical-websites/assets.ubuntu.com/issues/new">file a new issue</a>.
+            </p>
+          {% endif %}
+        </div>
       </div>
     </div>
   </div>
-</div>
 {% endblock content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,7 +30,7 @@
   {% endif %}
 
   <div class="p-strip is-shallow u-no-padding--bottom">
-    <div class="row">
+    <div class="grid-row">
       {% if assets %}
         {% include "_asset-list.html" %}
       {% endif %}

--- a/templates/shared/_asset-card-actions.html
+++ b/templates/shared/_asset-card-actions.html
@@ -1,8 +1,10 @@
 <div class="p-section--shallow">
         <button class="p-button--positive copy-link"
+                style="margin-right: 4%"
                 data-url="/v1/{{ asset.file_path }}">Asset link</button>
         {% if asset.data.image %}
                 <button class="p-button js-copy-image-tag"
+                        style="margin-right: 4%"
                         data-url="/v1/{{ asset.file_path }}">Dev tag</button>
         {% endif %}
         <a class="p-button"

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -79,7 +79,7 @@ def home():
     )
 
     if not per_page or per_page < 1 or per_page > 100:
-        per_page = 15
+        per_page = 16
     if order_by not in asset_service.order_by_fields():
         order_by = list(asset_service.order_by_fields().keys())[0]
     if order_dir not in ["asc", "desc"]:

--- a/webapp/services.py
+++ b/webapp/services.py
@@ -39,7 +39,7 @@ class AssetService:
         salesforce_campaign_id: str = "1234",
         language: str = "English",
         page=1,
-        per_page=6,
+        per_page=16,
         order_by=Asset.created,
         desc_order=True,
         include_deprecated=False,


### PR DESCRIPTION
## Done

- Changed classnames in templates to support new grid.
- Made changes to margins to match the design.
- Pagination is now in multiples of 16 to match the layout.
## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8017
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Run the site via `docker compose up` followed by `dotrun`.
- Check [Design](https://www.figma.com/design/dOz7GIHMmofSdje0l0pVFs/assets.ubuntu.com--Assets-manager-?node-id=766-11733&p=f&m=dev) and see if all layouts on demo are consistent.

## Issue / Card

Fixes # [WD-23825](https://warthogs.atlassian.net/browse/WD-23825)

## Screenshots

[if relevant, include a screenshot]
