### PR TITLE
Feat:(WD-24335) Refactored get-salesforce-campaigns

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pydantic-settings==2.10.1
 python-slugify==8.0.4
 trino==0.335.0
 google-auth==2.40.3
+cryptography==46.0.1

--- a/static/js/src/sf_campaign-search.js
+++ b/static/js/src/sf_campaign-search.js
@@ -47,7 +47,6 @@ function setUpCampaignSearchField() {
           }
         } catch (error) {
           console.error("Error fetching campaign data:", error);
-          alert("Failed to fetch campaign data");
         }
       } else {
         updateSearchResults([]);

--- a/static/js/src/sf_campaign-search.js
+++ b/static/js/src/sf_campaign-search.js
@@ -43,10 +43,11 @@ function setUpCampaignSearchField() {
           );
           if (response.ok) {
             const data = await response.json();
-            updateSearchResults(data);
+            updateSearchResults(data.campaigns);
           }
         } catch (error) {
           console.error("Error fetching campaign data:", error);
+          alert("Failed to fetch campaign data");
         }
       } else {
         updateSearchResults([]);

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -54,13 +54,16 @@ class TrinoSFConfig(BaseSettings):
         if not v:
             return v
         try:
-            decoded_bytes = base64.b64decode(v, validate=True).replace(b"\\n", b"\n")
+            decoded_bytes = base64.b64decode(v, validate=True).replace(
+                b"\\n", b"\n"
+            )
             decoded_str = decoded_bytes.decode("utf-8")
             if decoded_str.strip().startswith("-----BEGIN"):
                 return decoded_str
         except Exception:
-            pass  
+            pass
         return v
+
 
 class Config(BaseSettings):
     model_config = SettingsConfigDict(

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -1,5 +1,6 @@
 from pydantic import AliasChoices, SecretStr, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from webapp.lib.python_helpers import is_pem_private_key
 import base64
 
 ENV_FILES = (".env", ".env.local")
@@ -57,9 +58,8 @@ class TrinoSFConfig(BaseSettings):
             decoded_bytes = base64.b64decode(v, validate=True).replace(
                 b"\\n", b"\n"
             )
-            decoded_str = decoded_bytes.decode("utf-8")
-            if decoded_str.strip().startswith("-----BEGIN"):
-                return decoded_str
+            if is_pem_private_key(decoded_bytes):
+                return decoded_bytes
         except Exception:
             pass
         return v

--- a/webapp/integrations/trino_service.py
+++ b/webapp/integrations/trino_service.py
@@ -26,9 +26,9 @@ class TrinoClient:
             )
             credentials.refresh(self._request)
             return credentials.token
-        except Exception:
+        except Exception as e:
             logger.exception(
-                "Unable to refresh Trino service account token: ", Exception
+                "Unable to refresh Trino service account token: ", e
             )
             return None
 
@@ -36,16 +36,20 @@ class TrinoClient:
         token = self._get_token()
         if not token:
             return None
-        conn = connect(
-            host="candidate.trino.canonical.com",
-            port=443,
-            http_scheme="https",
-            auth=trino.auth.JWTAuthentication(token),
-            verify=True,
-            catalog="salesforce",
-            schema="canonical",
-        )
-        return conn.cursor()
+        try:
+            conn = connect(
+                host="candidate.trino.canonical.com",
+                port=443,
+                http_scheme="https",
+                auth=trino.auth.JWTAuthentication(token),
+                verify=True,
+                catalog="salesforce",
+                schema="canonical",
+            )
+            return conn.cursor()
+        except Exception as e:
+            logger.exception("Unable to connect to Trino: ", e)
+            return None
 
 
 trino_client = TrinoClient()

--- a/webapp/integrations/trino_service.py
+++ b/webapp/integrations/trino_service.py
@@ -1,44 +1,50 @@
+# trino_client.py
 import logging
-import sys
-
+from typing import Optional
 import trino.auth
-from webapp.config import config
-from google.auth.transport import requests
-from google.oauth2 import service_account
 from trino.dbapi import connect
-
+from google.auth.transport.requests import Request
+from google.oauth2 import service_account
+from webapp.config import config
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 
-def get_service_account_token():
-    try:
-        trino_service_account = config.trino_sf
-        service_account_dict = trino_service_account.model_dump()
-        credentials = service_account.Credentials.from_service_account_info(
-            service_account_dict, scopes=["openid", "email"]
+class TrinoClient:
+    def __init__(self):
+        self.scopes = ["openid", "email"]
+        self._request = Request()
+
+    def _get_token(self) -> Optional[str]:
+        try:
+            service_account_dict = config.trino_sf.model_dump()
+            credentials = service_account.Credentials.from_service_account_info(
+                service_account_dict,
+                scopes=self.scopes,
+            )
+            credentials.refresh(self._request)
+            return credentials.token
+        except Exception:
+            logger.exception(
+                "Unable to refresh Trino service account token: ", Exception
+            )
+            return None
+
+    def get_cursor(self):
+        token = self._get_token()
+        if not token:
+            return None
+        conn = connect(
+            host="candidate.trino.canonical.com",
+            port=443,
+            http_scheme="https",
+            auth=trino.auth.JWTAuthentication(token),
+            verify=True,
+            catalog="salesforce",
+            schema="canonical",
         )
-        credentials.refresh(requests.Request())
-        return credentials.token
-    except Exception as e:
-        logger.error(f"Failed to load Trino configuration: {e}")
-        return None
+        return conn.cursor()
 
 
-# Prepare the trino connection using the service account token
-token = get_service_account_token()
-if not token:
-    logger.error("Failed to obtain service account token.")
-    trino_cur = None
-else:
-    trino_conn = connect(
-        host="candidate.trino.canonical.com",
-        port=443,
-        http_scheme="https",
-        auth=trino.auth.JWTAuthentication(token),
-        verify=True,
-        catalog="salesforce",
-        schema="canonical",
-    )
-    trino_cur = trino_conn.cursor()
+trino_client = TrinoClient()
+trino_cur = trino_client.get_cursor()

--- a/webapp/integrations/trino_service.py
+++ b/webapp/integrations/trino_service.py
@@ -18,9 +18,11 @@ class TrinoClient:
     def _get_token(self) -> Optional[str]:
         try:
             service_account_dict = config.trino_sf.model_dump()
-            credentials = service_account.Credentials.from_service_account_info(
-                service_account_dict,
-                scopes=self.scopes,
+            credentials = (
+                service_account.Credentials.from_service_account_info(
+                    service_account_dict,
+                    scopes=self.scopes,
+                )
             )
             credentials.refresh(self._request)
             return credentials.token

--- a/webapp/lib/python_helpers.py
+++ b/webapp/lib/python_helpers.py
@@ -1,3 +1,7 @@
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.backends import default_backend
+
+
 def shared_items(list_one, list_two):
     """
     Return the list of items that are shared
@@ -11,3 +15,16 @@ def sanitize_like_input(raw: str) -> str:
     """Escape special characters used in SQL LIKE"""
     escaped = raw.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
     return escaped
+
+
+def is_pem_private_key(data: bytes) -> bool:
+    """
+    Return True if the given data is a valid PEM private key.
+    """
+    try:
+        serialization.load_pem_private_key(
+            data, password=None, backend=default_backend()
+        )
+        return True
+    except Exception:
+        return False

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -18,7 +18,6 @@ from webapp.services import (
     AssetAlreadyExistException,
     AssetNotFound,
     asset_service,
-    query_salesforce_campaigns,
 )
 from webapp.sso import login_required
 from webapp.views import (
@@ -36,6 +35,7 @@ from webapp.views import (
     get_token,
     get_tokens,
     get_users,
+    get_salesforce_campaigns,
     update_asset,
     update_redirect,
 )
@@ -307,7 +307,7 @@ def details():
 @ui_blueprint.route("/salesforce_campaigns/<query>", methods=["GET"])
 @login_required
 def campaign_operations(query):
-    return query_salesforce_campaigns(query)
+    return get_salesforce_campaigns(query)
 
 
 # API Routes

--- a/webapp/services.py
+++ b/webapp/services.py
@@ -450,5 +450,3 @@ class ReadOnlyMode(Exception):
 
 
 asset_service = AssetService()
-
-

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -462,7 +462,6 @@ def delete_redirect(redirect_path):
     return jsonify({}), 204
 
 
-@login_required
 def get_users(username: str):
     query = """
     query($name: String!) {
@@ -499,7 +498,6 @@ def get_users(username: str):
     return jsonify({"error": "Failed to fetch users"}), 500
 
 
-@login_required
 def get_salesforce_campaigns(query: str):
     safe_query = sanitize_like_input(query.strip())
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -17,7 +17,6 @@ from webapp.decorators import token_required
 from webapp.lib.python_helpers import sanitize_like_input
 from webapp.integrations.trino_service import trino_cur
 from webapp.param_parser import parse_asset_search_params
-from webapp.sso import login_required
 from webapp.lib.file_helpers import get_mimetype, remove_filename_hash
 from webapp.lib.http_helpers import set_headers_for_type
 from webapp.lib.processors import ImageProcessor

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -14,6 +14,8 @@ from flask import Response, abort, jsonify, redirect, request
 
 from webapp.database import db_session
 from webapp.decorators import token_required
+from webapp.lib.python_helpers import sanitize_like_input
+from webapp.integrations.trino_service import trino_cur
 from webapp.param_parser import parse_asset_search_params
 from webapp.sso import login_required
 from webapp.lib.file_helpers import get_mimetype, remove_filename_hash
@@ -495,3 +497,26 @@ def get_users(username: str):
         users = response.json().get("data", {}).get("employees", [])
         return jsonify(list(users))
     return jsonify({"error": "Failed to fetch users"}), 500
+
+@login_required
+def get_salesforce_campaigns(query: str):
+    safe_query = sanitize_like_input(query.strip())
+
+    # Add '%' wildcards safely
+    like_pattern = f"%{safe_query}%"
+
+    formed_query = (
+        f"SELECT Id, Name FROM Campaign "
+        f"WHERE Name LIKE '{like_pattern}' ESCAPE '\\' "
+        f"LIMIT 20"
+    )
+    if trino_cur is None:
+            return jsonify({"error": "Failed to connect to service"}), 503
+    try:
+        trino_cur.execute(formed_query)
+        rows = trino_cur.fetchall()
+        campaigns = [{"id": row[0], "name": row[1]} for row in rows]
+
+        return jsonify({"campaigns": campaigns}), 200
+    except Exception as exc:
+        return jsonify({"error": f"Failed to fetch campaigns"}), 500

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -498,6 +498,7 @@ def get_users(username: str):
         return jsonify(list(users))
     return jsonify({"error": "Failed to fetch users"}), 500
 
+
 @login_required
 def get_salesforce_campaigns(query: str):
     safe_query = sanitize_like_input(query.strip())
@@ -511,12 +512,12 @@ def get_salesforce_campaigns(query: str):
         f"LIMIT 20"
     )
     if trino_cur is None:
-            return jsonify({"error": "Failed to connect to service"}), 503
+        return jsonify({"error": "Failed to connect to service"}), 503
     try:
         trino_cur.execute(formed_query)
         rows = trino_cur.fetchall()
         campaigns = [{"id": row[0], "name": row[1]} for row in rows]
 
         return jsonify({"campaigns": campaigns}), 200
-    except Exception as exc:
-        return jsonify({"error": f"Failed to fetch campaigns"}), 500
+    except Exception:
+        return jsonify({"error": "Failed to fetch campaigns"}), 500


### PR DESCRIPTION
## Done
- Refactored get-salesforce-campaigns endpoint
- added support to decode base64 encoded key

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8017
- To run locally use `docker compose up` and `dotrun`
- Please ask for required creds.
- Check if you could connect to trino service and the campaigns are being fetched and displayed in UI in add-asset page.

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-24335
