### PR TITLE
Fix #314: Align thumbnails to the center

### DIFF
--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -36,6 +36,7 @@
   overflow: hidden;
   display: grid;
   place-items: center;
+  align-content: center;
 
   &.is-deprecated img {
     opacity: 0.5;


### PR DESCRIPTION
## Done

Aligns thumbnais to the center, so that the middle of the image (vertical portrait aspect ratio) is visible.

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8017
- Make sure the thumbnails are visible and readable.

## Issue / Card

Fixes #314

## Screenshots

Before:

<img width="719" height="837" alt="Image" src="https://github.com/user-attachments/assets/575e77cf-b71b-4c58-8e54-32a4e2b82e7c" />

After:


<img width="720" height="901" alt="Image" src="https://github.com/user-attachments/assets/6b747ce6-7079-4f0c-9235-4765ca280ca2" />
