### PR TITLE
chore(WD-36270): remove launchpad team membership validation on auth

### DIFF
--- a/webapp/sso.py
+++ b/webapp/sso.py
@@ -60,7 +60,9 @@ def init_sso(app):
     @app.route("/auth/callback")
     def oauth_callback():
         token = oauth.canonical.authorize_access_token()
-
+        user_email = token["userinfo"]["email"]
+        if not user_email.endswith("@canonical.com"):
+          flask.abort(403, description="Canonical employees only")
         flask.session["openid"] = {
             "identity_url": token["userinfo"]["iss"],
             "email": token["userinfo"]["email"],

--- a/webapp/sso.py
+++ b/webapp/sso.py
@@ -4,12 +4,6 @@ from urllib.parse import urljoin, urlparse
 
 import flask
 from authlib.integrations.flask_client import OAuth
-import requests
-
-from webapp.views import get_users_data
-
-SSO_TEAM = "canonical-content-people"
-LAUNCHPAD_API_URL = "https://api.launchpad.net/1.0"
 
 
 def is_safe_url(target):
@@ -66,31 +60,6 @@ def init_sso(app):
     @app.route("/auth/callback")
     def oauth_callback():
         token = oauth.canonical.authorize_access_token()
-        users, status_code = get_users_data(token["userinfo"]["name"])
-
-        if status_code != 200 or not users:
-            flask.abort(
-                403, description="Failed to fetch user data from directory."
-            )
-
-        response = requests.get(
-            f"{LAUNCHPAD_API_URL}/~{users[0]['launchpadId']}/super_teams",
-        )
-
-        if response.status_code != 200:
-            flask.abort(
-                403, description="Failed to fetch Launchpad team memberships."
-            )
-
-        memberships = response.json().get("entries", [])
-        if SSO_TEAM not in [team["name"] for team in memberships]:
-            flask.abort(
-                403,
-                description=(
-                    "Please make sure you are a member of the "
-                    "canonical-content-people team on Launchpad."
-                ),
-            )
 
         flask.session["openid"] = {
             "identity_url": token["userinfo"]["iss"],

--- a/webapp/sso.py
+++ b/webapp/sso.py
@@ -62,7 +62,7 @@ def init_sso(app):
         token = oauth.canonical.authorize_access_token()
         user_email = token["userinfo"]["email"]
         if not user_email.endswith("@canonical.com"):
-          flask.abort(403, description="Canonical employees only")
+            flask.abort(403, description="Canonical employees only")
         flask.session["openid"] = {
             "identity_url": token["userinfo"]["iss"],
             "email": token["userinfo"]["email"],


### PR DESCRIPTION
## Done

- Removed launchpad team membership validation

## QA

- Check out this pull request
- Copy creds from [pastebin](https://pastebin.canonical.com/p/kxBgzKZtK6/) and place in your `.local.env`
- Run the site using the command `task`
- View the site locally in your web browser at: http://localhost:8017/login?next=/manager
- Verify the auth works as expected

## Issue / Card

Fixes [WD-36270](https://warthogs.atlassian.net/browse/WD-36270)


[WD-36270]: https://warthogs.atlassian.net/browse/WD-36270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ